### PR TITLE
fix(mvcc): release row claims on transaction rollback

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/002-fix-tx-update-fk"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,6 @@ The system is an autonomous relational database management system.
 - Binary artifacts are built for Linux, macOS, and Windows on release. Ensure any new dependencies support cross-compilation on these targets.
 
 <!-- SPECKIT START -->
-/Users/gabriel.maeztu/repos/oxibase-fk/specs/001-foreign-key/plan.md
+/Users/gabriel.maeztu/repos/oxibase/specs/002-fix-tx-update-fk/plan.md
 <!-- SPECKIT END -->
 

--- a/specs/002-fix-tx-update-fk/checklists/requirements.md
+++ b/specs/002-fix-tx-update-fk/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Fix Transaction Updates with Foreign Keys
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The specification addresses a specific bug report regarding internal MVCC errors during transactional updates with foreign keys. The requirements and success criteria are directly tied to resolving this user-facing error and ensuring correct transaction semantics.

--- a/specs/002-fix-tx-update-fk/data-model.md
+++ b/specs/002-fix-tx-update-fk/data-model.md
@@ -1,0 +1,28 @@
+# Data Model: Fix Transaction Updates with Foreign Keys
+
+This feature does not introduce new user-facing database schemas, but it patches the internal data structures that manage Transactional Concurrency (MVCC).
+
+## Internal Entities
+
+### `TransactionVersionStore`
+A transaction-local store that tracks uncommitted row versions and holds locks/claims on rows in the global `VersionStore`.
+
+**Fields involved in the fix:**
+- `write_set`: A map of `row_id` to `WriteSetEntry`.
+- `parent_store`: A reference to the global `VersionStore`.
+
+**State Transitions:**
+1.  **Update (put):** Row is added to `write_set`. `parent_store.try_claim_row()` adds the row to `uncommitted_writes`.
+2.  **Commit:** Replaces old versions in `parent_store` with new ones from `local_versions`. Calls `release_all_claims()` to remove the row from `uncommitted_writes`.
+3.  **Rollback:** MUST call `release_all_claims()` to remove the row from `uncommitted_writes` and discard `local_versions`. (This was missing at the engine level).
+
+### `MvccEngine`
+The central engine that manages global tables and active transaction states.
+
+**Fields involved in the fix:**
+- `txn_version_stores`: A thread-safe cache (`DashMap` or `RwLock<HashMap>`) mapping `(txn_id, table_name)` to `TransactionVersionStore`.
+
+**State Transitions:**
+1.  **Transaction Start / Table Access:** An entry is inserted into `txn_version_stores`.
+2.  **Transaction Commit:** `commit_all_tables()` flushes changes and removes the `txn_id` entries from `txn_version_stores`.
+3.  **Transaction Rollback:** **NEW BEHAVIOR** `rollback_all_tables()` will explicitly call rollback on each cached store and remove the `txn_id` entries from `txn_version_stores`.

--- a/specs/002-fix-tx-update-fk/plan.md
+++ b/specs/002-fix-tx-update-fk/plan.md
@@ -1,0 +1,60 @@
+# Implementation Plan: Fix Transaction Updates with Foreign Keys
+
+**Branch**: `002-fix-tx-update-fk` | **Date**: 2026-05-05 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/002-fix-tx-update-fk/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Resolve an internal bug where rolling back a transaction fails to release row claims in the `MvccEngine` cache, leading to persistent "uncommitted changes" errors on subsequent queries. The fix involves adding a `rollback_all_tables` method to `TransactionEngineOperations` and implementing it in `MvccEngine` to properly cascade rollbacks and release MVCC row locks, bringing rollback cache handling inline with the existing commit logic.
+
+## Technical Context
+
+**Language/Version**: Rust 1.85+ (expected for modern backend)
+**Primary Dependencies**: `dashmap`
+**Testing**: `cargo nextest` (via `make test` / `make test-all`)
+**Target Platform**: Embedded Monolithic DB (Linux, macOS, Windows)
+**Performance Goals**: Zero-Copy Unikernel memory efficiency
+**Constraints**: No `unwrap()`, strict ACID compliance, MVCC logic required, must pass `make lint` and `make license`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **Mainframe Monolith**: Does this maintain the embedded/monolith architecture? (Yes, internal bugfix)
+- [x] **ACID & MVCC**: Does this change respect multi-version concurrency control and strict data integrity? (Yes, explicitly fixes an MVCC leak)
+- [x] **Memory Efficiency**: Does this avoid unnecessary allocations (e.g., `Vec` clones)? (Yes, strictly operates on cache references)
+- [x] **Safe Rust**: Are errors properly propagated? (No `unwrap()`, `expect()`, `todo!()`, `unimplemented!()`, or unjustified `unsafe`) (Yes)
+- [x] **Tests First**: Will this be covered by tests that can be verified via `cargo nextest`? (Yes, integration tests covering transactions with FK constraints)
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-fix-tx-update-fk/
+├── plan.md              # This file
+├── research.md          # Research into the rollback cache leak
+├── data-model.md        # State transitions of TransactionVersionStore
+├── quickstart.md        # Steps to verify the fix
+└── tasks.md             # Phase 2 output (future command)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── storage/
+│   ├── mvcc/
+│   │   ├── engine.rs      # Implementing `rollback_all_tables`
+│   │   ├── transaction.rs # Updating `MvccTransaction::rollback` and `TransactionEngineOperations` trait
+│   │   └── version_store.rs # Implementing `Drop` for safety net
+tests/                 # Integration tests for transaction rollback & constraints
+```
+
+**Structure Decision**: This feature exclusively impacts `src/storage/mvcc/` because it addresses an internal logic flaw in how MVCC state caching handles rollbacks.
+
+## Complexity Tracking
+
+*No Constitution Check violations expected.*

--- a/specs/002-fix-tx-update-fk/quickstart.md
+++ b/specs/002-fix-tx-update-fk/quickstart.md
@@ -1,0 +1,52 @@
+# Quickstart: Fix Transaction Updates with Foreign Keys
+
+## Testing the Fix
+
+You can verify the bug fix by running the sequence of SQL commands that previously triggered the error.
+
+```sql
+-- Start CLI
+cargo run
+
+-- In the CLI, execute the sequence:
+CREATE TABLE products (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    price FLOAT NOT NULL,
+    category TEXT,
+    in_stock BOOLEAN,
+    created_at TIMESTAMP
+);
+
+INSERT INTO products (id, name, description, price, category, in_stock, created_at)
+VALUES (1, 'Laptop', 'High-performance laptop with 16GB RAM', 1299.99, 'Electronics', TRUE, NOW());
+
+BEGIN TRANSACTION;
+UPDATE products SET price = price * 0.9 WHERE category = 'Electronics';
+ROLLBACK;
+
+CREATE TABLE categories (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT
+);
+
+INSERT INTO categories (id, name, description) VALUES (1, 'Electronics', 'Electronic devices and gadgets');
+
+ALTER TABLE products ADD COLUMN category_id INTEGER;
+UPDATE products SET category_id = 1 WHERE category = 'Electronics';
+
+-- This should now succeed without the "uncommitted changes" error
+ALTER TABLE products ADD CONSTRAINT fk_category FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL;
+```
+
+## Running Automated Tests
+
+A new integration test will be added to ensure this doesn't regress.
+
+```bash
+make test
+# OR
+cargo nextest run --profile ci
+```

--- a/specs/002-fix-tx-update-fk/research.md
+++ b/specs/002-fix-tx-update-fk/research.md
@@ -1,0 +1,58 @@
+# Research: Fix Transaction Updates with Foreign Keys
+
+## Problem Context
+When executing the Oxibase CLI with a transaction that updates rows with foreign keys, a `ROLLBACK` fails to release the transaction's row claims. Subsequent operations (like `ALTER TABLE` constraint checks or further updates) fail with:
+`Error: internal error: row <ID> has uncommitted changes from transaction <TXN_ID>`
+
+## Findings
+
+1. **Transaction Caching & Row Claims:**
+   - When a transaction updates a row, it calls `TransactionVersionStore::put`, which adds the row to its `write_set` and claims the row in the parent `VersionStore`'s `uncommitted_writes`.
+   - To release the claim, `TransactionVersionStore::rollback()` or `commit()` calls `release_all_claims()`.
+
+2. **The Rollback Bug in `MvccTransaction`:**
+   - `MvccTransaction::rollback()` attempts to roll back local changes by iterating over `self.tables`.
+   - However, `self.tables` is rarely populated because `MvccTransaction::get_table()` delegates to the engine and explicitly notes: "For now, always get from engine (engine will handle caching internally)."
+   - Because `self.tables` is empty, `table.rollback()` is never called.
+
+3. **The Memory Leak in `MvccEngine`:**
+   - `MvccEngine` caches the transaction-local stores in `self.txn_version_stores`.
+   - `MvccEngine::commit_all_tables()` properly cleans up this cache using `cache.retain(...)`.
+   - There is no equivalent `rollback_all_tables()` method. When a transaction rolls back, the `TransactionVersionStore` remains in the engine's cache indefinitely.
+   - Since `TransactionVersionStore` does not implement `Drop`, its row claims are never released, permanently locking the rows.
+
+## Decision
+
+**Add `rollback_all_tables` to `TransactionEngineOperations` and `MvccEngine`.**
+
+- **Rationale:** Just as `commit_all_tables` handles the centralized commit and cleanup of the engine's `txn_version_stores` cache, a symmetric `rollback_all_tables` will cleanly iterate over the cache, call `rollback()` on each store (which releases row claims), and then remove the transaction's entries from the cache.
+- **Alternatives considered:** We could populate `self.tables` in `MvccTransaction::get_table()`, but the code comment explicitly warns that `Table` doesn't implement `Clone` and it's better to let the engine handle caching. We could also implement `Drop` for `TransactionVersionStore`, but explicit resource cleanup via `rollback_all_tables` is more predictable and avoids relying on garbage collection timing, though `Drop` can be added as a defense-in-depth measure.
+
+## Implementation Plan
+
+1.  **Modify `TransactionEngineOperations` (in `src/storage/mvcc/transaction.rs`)**
+    - Add `fn rollback_all_tables(&self, txn_id: i64) -> Result<()>;`
+
+2.  **Modify `MvccEngine` (in `src/storage/mvcc/engine.rs`)**
+    - Implement `rollback_all_tables`:
+      ```rust
+      fn rollback_all_tables(&self, txn_id: i64) -> Result<()> {
+          let cache = self.txn_version_stores().read().unwrap();
+          for ((cached_txn_id, _), txn_store) in cache.iter() {
+              if *cached_txn_id == txn_id {
+                  txn_store.write().unwrap().rollback();
+              }
+          }
+          drop(cache);
+          let mut cache = self.txn_version_stores().write().unwrap();
+          cache.retain(|(cached_txn_id, _), _| *cached_txn_id != txn_id);
+          Ok(())
+      }
+      ```
+
+3.  **Modify `MvccTransaction::rollback` (in `src/storage/mvcc/transaction.rs`)**
+    - Call `ops.rollback_all_tables(self.id)` instead of iterating over `self.tables` to notify the engine.
+    - Remove the existing loops for `table.rollback()` and `ops.rollback_table()` since `rollback_all_tables` handles it at the engine level.
+
+4.  **Add `Drop` for `TransactionVersionStore` (in `src/storage/mvcc/version_store.rs`)** (Optional but recommended)
+    - Implement `Drop` to call `self.release_all_claims()` to prevent any future leaks if a transaction panics or is dropped without commit/rollback.

--- a/specs/002-fix-tx-update-fk/spec.md
+++ b/specs/002-fix-tx-update-fk/spec.md
@@ -1,0 +1,68 @@
+# Feature Specification: Fix Transaction Updates with Foreign Keys
+
+**Feature Branch**: `002-fix-tx-update-fk`  
+**Created**: 2026-05-05  
+**Status**: Draft  
+**Input**: User description: "when executing the oxibase cli i get some error in this sequence of steps... Error: internal error: row 2 has uncommitted changes from transaction 9... Error: internal error: row 3 has uncommitted changes from transaction 9"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Commit Updates with Foreign Keys in Transactions (Priority: P1)
+
+Users must be able to successfully update rows that are referenced by foreign keys within a transaction, and commit those changes without internal MVCC errors.
+
+**Why this priority**: Transactional integrity is a core database feature. Internal errors during normal SQL operations (like updates within a transaction) indicate a severe bug that breaks basic functionality and trust.
+
+**Independent Test**: Can be fully tested by a new integration test mimicking the user's script: creating tables with an FK constraint, starting a transaction, updating referenced rows, and committing, verifying it succeeds without error.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `categories` table and a `products` table with a foreign key referencing `categories`, **When** a user starts a transaction, updates multiple `products` rows, and attempts to commit, **Then** the transaction should commit successfully, returning the updated rows upon query.
+2. **Given** a transaction modifying rows, **When** those rows are referenced by a newly added foreign key constraint in the same or subsequent transaction, **Then** updates should process correctly without MVCC conflicts against itself.
+
+---
+
+### User Story 2 - Rollback Updates with Foreign Keys in Transactions (Priority: P2)
+
+Users must be able to successfully roll back updates to rows that are referenced by foreign keys, restoring the state prior to the transaction without internal MVCC errors.
+
+**Why this priority**: Rollback functionality is just as critical as commit functionality for ACID compliance. The reported script also shows a rollback scenario before the error.
+
+**Independent Test**: Can be fully tested by a new integration test that starts a transaction, updates referenced rows, rolls back, and verifies the original state is restored without errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a transaction updating referenced rows, **When** the user issues a `ROLLBACK`, **Then** the transaction should abort, and the rows should revert to their pre-transaction state without throwing "uncommitted changes" errors on subsequent operations.
+
+### Edge Cases
+
+- What happens when concurrent transactions attempt to update the same rows referenced by foreign keys?
+- How does the system handle an `ALTER TABLE ADD CONSTRAINT` operation immediately following transactions that updated the referenced data?
+- How does MVCC track active transaction IDs for rows involved in referential integrity checks?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Engine MUST correctly manage MVCC row versions during `UPDATE` operations within a transaction so that subsequent operations or commits recognize the transaction's own changes.
+- **FR-002**: Storage MUST NOT incorrectly flag rows modified by the *current* transaction as having "uncommitted changes" from a conflicting transaction when performing foreign key checks or final commits.
+- **FR-003**: System MUST correctly handle the interaction between transaction state and newly applied schema constraints (like `ALTER TABLE ADD CONSTRAINT`).
+
+### Key Entities
+
+- **Transaction Manager**: Tracks active transactions and their modifications.
+- **MVCC Versioning**: Manages visibility and uncommitted changes for rows.
+- **Foreign Key Checker**: Validates referential integrity, which must interact correctly with MVCC visibility rules for the active transaction.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The exact SQL script provided by the user executes successfully without throwing "Error: internal error: row X has uncommitted changes from transaction Y".
+- **SC-002**: Passes all new integration tests covering transactions, updates, and foreign key constraints.
+- **SC-003**: Passes `make lint` and `cargo nextest` without regressions in existing functionality.
+
+## Assumptions
+
+- The issue stems from the interaction between how `UPDATE` modifies row versions and how the transaction manager tracks uncommitted changes, specifically exposed when foreign key constraints necessitate row lookups or validations.
+- The user's provided SQL script is standard SQL and should be fully supported by Oxibase.

--- a/specs/002-fix-tx-update-fk/tasks.md
+++ b/specs/002-fix-tx-update-fk/tasks.md
@@ -1,0 +1,90 @@
+---
+description: "Task list for fixing the transaction updates with foreign keys bug"
+---
+
+# Tasks: Fix Transaction Updates with Foreign Keys
+
+**Input**: Design documents from `/specs/002-fix-tx-update-fk/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Tests**: MUST include corresponding `cargo nextest` integration tests.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- `src/storage/mvcc/` for MVCC and engine state changes
+- `tests/` for integration tests
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Project initialization and basic structure
+
+*(No general setup tasks needed, as the project is already initialized and the fix operates on existing files)*
+
+---
+
+## Phase 2: Foundational Changes
+
+**Purpose**: Shared infrastructure and trait changes required by all user stories.
+
+- [X] T001 Define `rollback_all_tables(&self, txn_id: i64) -> Result<()>` in the `TransactionEngineOperations` trait in `src/storage/mvcc/transaction.rs`.
+
+---
+
+## Phase 3: User Story 2 - Rollback Updates with Foreign Keys in Transactions (Priority: P2)
+
+**Goal**: Users must be able to successfully roll back updates to rows that are referenced by foreign keys, restoring the state prior to the transaction without internal MVCC errors.
+*Note: Addressed before US1 because the specific engine leak (cache not cleared on rollback) is the root cause preventing subsequent operations (like adding FKs and committing).*
+
+**Independent Test**: `tests/transaction_rollback_fk_test.rs` (or similar existing transaction test file)
+
+### Tests for User Story 2 ⚠️
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T002 [US2] Create or update an integration test in `tests/transaction_fk.rs` that starts a transaction, updates rows referenced by foreign keys, executes `ROLLBACK`, and verifies that subsequent operations (like `ALTER TABLE ADD CONSTRAINT` or new updates) succeed.
+
+### Implementation for User Story 2
+
+- [X] T003 [P] [US2] Implement `rollback_all_tables` in `MVCCEngine` within `src/storage/mvcc/engine.rs` to iterate over `txn_version_stores`, call `rollback()` on matching stores, and then `retain` only those stores belonging to other transactions.
+- [X] T004 [US2] Update `MvccTransaction::rollback` in `src/storage/mvcc/transaction.rs` to call `ops.rollback_all_tables(self.id)` instead of the current incomplete loop over `self.tables`. Remove the redundant calls to `ops.rollback_table` as they will be handled by the new `rollback_all_tables` function.
+- [X] T005 [P] [US2] Implement the `Drop` trait for `TransactionVersionStore` in `src/storage/mvcc/version_store.rs` to automatically call `self.release_all_claims()` as a defense-in-depth measure against panics or dropped transactions.
+- [X] T006 [US2] Run `cargo nextest run` to verify the new integration test passes and the rollback behavior successfully clears row claims.
+
+---
+
+## Phase 4: User Story 1 - Commit Updates with Foreign Keys in Transactions (Priority: P1) 🎯 MVP
+
+**Goal**: Users must be able to successfully update rows that are referenced by foreign keys within a transaction, and commit those changes without internal MVCC errors.
+*Note: With the rollback leak fixed and the engine cache management unified, the commit path and subsequent constraint additions will succeed.*
+
+**Independent Test**: Included in the same test file.
+
+### Tests for User Story 1 ⚠️
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T007 [US1] Add a test case in `tests/transaction_fk.rs` that updates rows referenced by foreign keys inside a transaction, commits the transaction, and verifies the update persists and constraints are respected without MVCC internal errors.
+
+### Implementation for User Story 1
+
+- [X] T008 [US1] The foundational changes in Phase 2 & 3 address the caching architecture flaw that also affects sequential transaction integrity. Verify that no further `VersionStore` or `MvccEngine` changes are required for the commit path. 
+- [X] T009 [US1] Run `make test` and `make lint` to ensure no regressions and that the complete user script (as reported) executes flawlessly.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [X] T010 [P] Verify `make license` passes to ensure new test files have the correct Apache-2.0 header.
+- [X] T011 Verify `unwrap()` and `expect()` are not used inappropriately in the new `engine.rs` or `version_store.rs` code (handle lock acquisition properly if needed, though `.unwrap()` on `RwLock` is standard in this codebase for panic-on-poisoning).

--- a/src/executor/aggregation.rs
+++ b/src/executor/aggregation.rs
@@ -2570,10 +2570,7 @@ impl Executor {
 
         // Convert groups to Vec for parallel processing
         // Flatten buckets: each bucket may contain multiple groups (hash collisions)
-        let groups_vec: Vec<GroupEntry> = groups
-            .into_iter()
-            .flat_map(|(_hash, bucket)| bucket)
-            .collect();
+        let groups_vec: Vec<GroupEntry> = groups.into_values().flatten().collect();
 
         // Pre-compile aggregate filter and expression programs for VM-based evaluation
         // CRITICAL: Propagate errors instead of silently ignoring compilation failures

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -364,33 +364,28 @@ impl Executor {
                         // Handle qualified column names like "c.name" for ORDER BY
                         // First, try matching against SELECT expressions directly
                         for (i, select_expr) in stmt.columns.iter().enumerate() {
-                            match select_expr {
-                                Expression::QualifiedIdentifier(sel_qid) => {
-                                    // Direct match: ORDER BY c.name matches SELECT c.name
+                            if let Expression::QualifiedIdentifier(sel_qid) = select_expr {
+                                // Direct match: ORDER BY c.name matches SELECT c.name
+                                if sel_qid.qualifier.value_lower == qid.qualifier.value_lower
+                                    && sel_qid.name.value_lower == qid.name.value_lower
+                                {
+                                    return Some(i);
+                                }
+                            } else if let Expression::Aliased(aliased) = select_expr {
+                                // Check if the aliased expression matches
+                                if let Expression::QualifiedIdentifier(sel_qid) =
+                                    aliased.expression.as_ref()
+                                {
                                     if sel_qid.qualifier.value_lower == qid.qualifier.value_lower
                                         && sel_qid.name.value_lower == qid.name.value_lower
                                     {
                                         return Some(i);
                                     }
                                 }
-                                Expression::Aliased(aliased) => {
-                                    // Check if the aliased expression matches
-                                    if let Expression::QualifiedIdentifier(sel_qid) =
-                                        aliased.expression.as_ref()
-                                    {
-                                        if sel_qid.qualifier.value_lower
-                                            == qid.qualifier.value_lower
-                                            && sel_qid.name.value_lower == qid.name.value_lower
-                                        {
-                                            return Some(i);
-                                        }
-                                    }
-                                    // Also check if the alias matches the base column name
-                                    if aliased.alias.value_lower == qid.name.value_lower {
-                                        return Some(i);
-                                    }
+                                // Also check if the alias matches the base column name
+                                if aliased.alias.value_lower == qid.name.value_lower {
+                                    return Some(i);
                                 }
-                                _ => {}
                             }
                         }
                         // Fallback: try matching against column names

--- a/src/executor/query.rs
+++ b/src/executor/query.rs
@@ -5955,11 +5955,9 @@ impl Executor {
                 }
                 match value {
                     Value::Integer(id) => all_row_ids.push(*id),
-                    Value::Float(f) => {
+                    Value::Float(f) if f.fract() == 0.0 => {
                         // Handle case where integer was stored as float
-                        if f.fract() == 0.0 {
-                            all_row_ids.push(*f as i64);
-                        }
+                        all_row_ids.push(*f as i64);
                     }
                     _ => {}
                 }

--- a/src/executor/statistics.rs
+++ b/src/executor/statistics.rs
@@ -174,11 +174,7 @@ impl Executor {
 
         // Calculate average row size
         let total_size: usize = rows.iter().map(|r| self.estimate_row_size(r)).sum();
-        let avg_row_size = if actual_row_count > 0 {
-            total_size / actual_row_count
-        } else {
-            0
-        };
+        let avg_row_size = total_size.checked_div(actual_row_count).unwrap_or(0);
 
         // Estimate page count (assuming 8KB pages)
         let page_count = (total_size / 8192).max(1);

--- a/src/optimizer/workload.rs
+++ b/src/optimizer/workload.rs
@@ -533,7 +533,7 @@ impl WorkloadLearner {
             .map(|(k, v)| (k.clone(), v.load(Ordering::Relaxed)))
             .collect();
 
-        tables.sort_by(|a, b| b.1.cmp(&a.1));
+        tables.sort_by_key(|b| std::cmp::Reverse(b.1));
         tables.truncate(limit);
         tables
     }

--- a/src/storage/expression/in_list.rs
+++ b/src/storage/expression/in_list.rs
@@ -148,14 +148,8 @@ impl InListExpr {
                         Value::Integer(i) => {
                             set.insert(*i);
                         }
-                        Value::Float(f) => {
-                            // Only include if it's a whole number
-                            if f.fract() == 0.0 {
-                                set.insert(*f as i64);
-                            } else {
-                                all_int = false;
-                                break;
-                            }
+                        Value::Float(f) if f.fract() == 0.0 => {
+                            set.insert(*f as i64);
                         }
                         Value::Null(_) => {} // Skip nulls
                         _ => {

--- a/src/storage/mvcc/engine.rs
+++ b/src/storage/mvcc/engine.rs
@@ -2992,6 +2992,23 @@ impl TransactionEngineOperations for EngineOperations {
         Ok(())
     }
 
+    fn rollback_all_tables(&self, txn_id: i64) -> Result<()> {
+        let cache = self.txn_version_stores().read().unwrap();
+
+        for ((cached_txn_id, _), txn_store) in cache.iter() {
+            if *cached_txn_id == txn_id {
+                txn_store.write().unwrap().rollback();
+            }
+        }
+
+        // Clean up the transaction version store cache for this transaction
+        drop(cache);
+        let mut cache = self.txn_version_stores().write().unwrap();
+        cache.retain(|(cached_txn_id, _), _| *cached_txn_id != txn_id);
+
+        Ok(())
+    }
+
     fn create_schema(&self, name: &str) -> Result<()> {
         let name_lower = name.to_lowercase();
         let mut schemas = self.schemas.write().unwrap();

--- a/src/storage/mvcc/transaction.rs
+++ b/src/storage/mvcc/transaction.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Stoolap Contributors
+// Copyright 2025 Oxibase Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -110,6 +111,9 @@ pub trait TransactionEngineOperations: Send + Sync {
 
     /// Commit all tables for a transaction at once
     fn commit_all_tables(&self, txn_id: i64) -> Result<()>;
+
+    /// Rollback all tables for a transaction at once
+    fn rollback_all_tables(&self, txn_id: i64) -> Result<()>;
 }
 
 impl MvccTransaction {
@@ -406,15 +410,13 @@ impl Transaction for MvccTransaction {
             );
         }
 
-        // Rollback all tables - discard local changes
-        for (_, table) in self.tables.iter_mut() {
-            table.rollback();
-        }
-
-        // Notify engine of rollback
+        // Rollback all tables - discard local changes and release claims at the engine level
         if let Some(ops) = &self.engine_operations {
-            for (_, table) in self.tables.iter() {
-                ops.rollback_table(self.id, table.as_ref());
+            if let Err(e) = ops.rollback_all_tables(self.id) {
+                eprintln!(
+                    "Warning: Failed to rollback all tables for transaction {}: {}",
+                    self.id, e
+                );
             }
         }
 

--- a/src/storage/mvcc/version_store.rs
+++ b/src/storage/mvcc/version_store.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Stoolap Contributors
+// Copyright 2025 Oxibase Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2522,6 +2523,12 @@ impl TransactionVersionStore {
         for (row_id, _) in self.write_set.iter() {
             self.parent_store.release_row_claim(*row_id, self.txn_id);
         }
+    }
+}
+
+impl Drop for TransactionVersionStore {
+    fn drop(&mut self) {
+        self.release_all_claims();
     }
 }
 

--- a/tests/transaction_fk.rs
+++ b/tests/transaction_fk.rs
@@ -1,0 +1,140 @@
+// Copyright 2026 Oxibase Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use oxibase::api::database::Database;
+
+#[test]
+fn test_transaction_rollback_fk() {
+    let db = Database::open_in_memory().unwrap();
+
+    db.execute(
+        "CREATE TABLE products (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            price FLOAT NOT NULL,
+            category TEXT
+        );",
+        (),
+    )
+    .unwrap();
+
+    db.execute(
+        "INSERT INTO products (id, name, price, category) VALUES 
+         (1, 'Laptop', 1000.0, 'Electronics');",
+        (),
+    )
+    .unwrap();
+
+    // Start a transaction, update, and rollback
+    let mut txn = db.begin().unwrap();
+    txn.execute(
+        "UPDATE products SET price = 900.0 WHERE category = 'Electronics';",
+        (),
+    )
+    .unwrap();
+    txn.rollback().unwrap();
+
+    // The rollback should have released row locks. Let's try adding a foreign key now.
+    db.execute(
+        "CREATE TABLE categories (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL
+        );",
+        (),
+    )
+    .unwrap();
+
+    db.execute(
+        "INSERT INTO categories (id, name) VALUES (1, 'Electronics');",
+        (),
+    )
+    .unwrap();
+    db.execute("ALTER TABLE products ADD COLUMN category_id INTEGER;", ())
+        .unwrap();
+    db.execute(
+        "UPDATE products SET category_id = 1 WHERE category = 'Electronics';",
+        (),
+    )
+    .unwrap();
+
+    // This should NOT fail with "row has uncommitted changes"
+    let res = db.execute("ALTER TABLE products ADD CONSTRAINT fk_category FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL;", ());
+    assert!(
+        res.is_ok(),
+        "Expected constraint addition to succeed, but got: {:?}",
+        res.err()
+    );
+}
+
+#[test]
+fn test_transaction_commit_fk() {
+    let db = Database::open_in_memory().unwrap();
+
+    db.execute(
+        "CREATE TABLE products (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            price FLOAT NOT NULL,
+            category TEXT
+        );",
+        (),
+    )
+    .unwrap();
+
+    db.execute(
+        "INSERT INTO products (id, name, price, category) VALUES 
+         (1, 'Laptop', 1000.0, 'Electronics');",
+        (),
+    )
+    .unwrap();
+
+    db.execute(
+        "CREATE TABLE categories (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL
+        );",
+        (),
+    )
+    .unwrap();
+
+    db.execute(
+        "INSERT INTO categories (id, name) VALUES (1, 'Electronics');",
+        (),
+    )
+    .unwrap();
+    db.execute("ALTER TABLE products ADD COLUMN category_id INTEGER;", ())
+        .unwrap();
+    db.execute(
+        "UPDATE products SET category_id = 1 WHERE category = 'Electronics';",
+        (),
+    )
+    .unwrap();
+    db.execute("ALTER TABLE products ADD CONSTRAINT fk_category FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL;", ()).unwrap();
+
+    // Start a transaction, update referenced row, and commit
+    let mut txn = db.begin().unwrap();
+    txn.execute(
+        "UPDATE products SET price = 850.0 WHERE category = 'Electronics';",
+        (),
+    )
+    .unwrap();
+    let res = txn.commit();
+
+    // The commit should succeed without "row has uncommitted changes"
+    assert!(
+        res.is_ok(),
+        "Expected commit to succeed, but got: {:?}",
+        res.err()
+    );
+}


### PR DESCRIPTION
## Summary
- Fixes an issue where transaction rollbacks left orphaned row claims in the MVCC engine cache
- Adds `rollback_all_tables` to cleanly release locks
- Implements `Drop` for `TransactionVersionStore` as a defense-in-depth measure
- Adds integration tests for transaction update and rollback with foreign keys
- Includes generated `speckit` specs and planning documents