### PR TITLE
feat(triggers): Context Refactor for Scripting Backends

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/011-script-engines"
+  "feature_directory": "specs/012-scripting-context"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,6 @@ The system is an autonomous relational database management system.
 - Binary artifacts are built for Linux, macOS, and Windows on release. Ensure any new dependencies support cross-compilation on these targets.
 
 <!-- SPECKIT START -->
-/Users/gabriel.maeztu/repos/oxibase/specs/011-script-engines/plan.md
+/Users/gabriel.maeztu/repos/oxibase/specs/012-scripting-context/plan.md
 <!-- SPECKIT END -->
 

--- a/docs/_docs/tutorials/triggers.md
+++ b/docs/_docs/tutorials/triggers.md
@@ -36,7 +36,7 @@ CREATE TRIGGER ensure_positive_balance
     FOR EACH ROW
     LANGUAGE rhai
 AS '
-    if NEW.balance < 0.0 {
+    if oxibase.ctx["new"].balance < 0.0 {
         throw "Account balance cannot be negative!";
     }
 ';
@@ -66,7 +66,7 @@ CREATE TRIGGER normalize_owner_name
     LANGUAGE js
 AS '
     // Force the owner name to be uppercase before saving
-    NEW.owner_name = NEW.owner_name.toUpperCase();
+    oxibase.ctx.new.owner_name = oxibase.ctx.new.owner_name.toUpperCase();
 ';
 ```
 
@@ -99,9 +99,9 @@ AS '
 import oxibase
 
 # Only log if the balance actually changed
-if OLD["balance"] != NEW["balance"]:
+if oxibase.ctx.old["balance"] != oxibase.ctx.new["balance"]:
     # Use oxibase.execute to run DML side-effects
-    stmt = "INSERT INTO audit_log (account_id, old_balance, new_balance) VALUES (" + str(OLD["id"]) + ", " + str(OLD["balance"]) + ", " + str(NEW["balance"]) + ")"
+    stmt = "INSERT INTO audit_log (account_id, old_balance, new_balance) VALUES (" + str(oxibase.ctx.old["id"]) + ", " + str(oxibase.ctx.old["balance"]) + ", " + str(oxibase.ctx.new["balance"]) + ")"
     oxibase.execute(stmt)
 ';
 ```

--- a/specs/012-scripting-context/checklists/requirements.md
+++ b/specs/012-scripting-context/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Scripting Backend Context Refactor (oxibase.ctx)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: May 13 2026
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/012-scripting-context/contracts/trigger-context.md
+++ b/specs/012-scripting-context/contracts/trigger-context.md
@@ -1,0 +1,21 @@
+# API Contract: Trigger Context API (oxibase.ctx)
+
+This contract defines the public namespace injected into trigger scripting environments (Python, JS, Rhai).
+
+## `oxibase.ctx`
+
+The context object guarantees the availability of the following structures:
+
+### `oxibase.ctx.old`
+Represents the state of the row *before* the DML operation (UPDATE or DELETE). 
+- **Type**: Dictionary/Object mapping column names to scalar values.
+- **Nullability**: Will be undefined/null during `INSERT` triggers.
+- **Mutability**: Strictly read-only.
+
+### `oxibase.ctx.new`
+Represents the state of the row *during or after* the DML operation (INSERT or UPDATE).
+- **Type**: Dictionary/Object mapping column names to scalar values.
+- **Nullability**: Will be undefined/null during `DELETE` triggers.
+- **Mutability**: 
+  - **BEFORE Triggers**: Mutable. Changes made to properties within this object will be intercepted by the engine and written directly to the database layer.
+  - **AFTER Triggers**: Read-only. Values reflect the data that has already been persisted to disk.

--- a/specs/012-scripting-context/data-model.md
+++ b/specs/012-scripting-context/data-model.md
@@ -1,0 +1,5 @@
+# Data Model: Scripting Backend Context Refactor
+
+This feature does not introduce any new database tables, internal core data structures, logical execution nodes, or physical AST changes. 
+
+The scope is strictly limited to the translation layer sitting between Oxibase's `Row` struct and the dynamic scripting environments representations (`NewRowProxy`, `PyDict`, `JsObject`).

--- a/specs/012-scripting-context/plan.md
+++ b/specs/012-scripting-context/plan.md
@@ -1,0 +1,56 @@
+# Implementation Plan: Scripting Backend Context Refactor (oxibase.ctx)
+
+**Branch**: `012-scripting-context` | **Date**: May 13 2026 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/012-scripting-context/spec.md`
+
+## Summary
+
+This feature refactors how the `old` and `new` row proxies are exposed to the embedded scripting engines (Python, JS/Boa, and Rhai) inside triggers. It removes the magic global `OLD` and `NEW` variables and encapsulates them cleanly under an `oxibase.ctx` object context (`oxibase.ctx.old` and `oxibase.ctx.new`).
+
+## Technical Context
+
+**Language/Version**: Rust 1.85+
+**Primary Dependencies**: `rhai`, `boa_engine` (js), `rustpython-vm` (python)
+**Testing**: `cargo nextest run --features js,python`
+**Target Platform**: Embedded Monolithic DB (Linux, macOS, Windows)
+**Performance Goals**: No added memory overhead from the nested dictionary/object abstraction.
+**Constraints**: No `unwrap()`, proper error propagation via `Result` through the JS and Python object interaction boundaries.
+
+## Constitution Check
+
+- [x] **Mainframe Monolith**: Does this maintain the embedded/monolith architecture? Yes, this refines internal scripting without breaking architecture.
+- [x] **ACID & MVCC**: Does this change respect multi-version concurrency control and strict data integrity? Yes, the underlying row proxies are unchanged; only the pointer paths change.
+- [x] **Memory Efficiency**: Does this avoid unnecessary allocations? Yes, we are simply allocating basic context dictionaries/objects once per execution instead of polluting the global scope.
+- [x] **Safe Rust**: Are errors properly propagated? Yes, we will rigorously handle `PyResult` and `JsResult` instead of using `unwrap()`.
+- [x] **Tests First**: Will this be covered by tests that can be verified via `cargo nextest`? Yes, tests will be explicitly modified and run to verify this refactoring.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-scripting-context/
+├── plan.md              # This file
+├── research.md          # N/A
+├── data-model.md        # N/A
+├── contracts/           # API Contract Documentation
+└── tasks.md             # Task Breakdown
+```
+
+### Source Code Impacts
+
+```text
+src/
+└── functions/
+    └── backends/
+        ├── rhai.rs      # Modifying global scope injection
+        ├── boa.rs       # Modifying global object property assignment and extraction
+        └── python.rs    # Modifying PyDict creation and injection into the sys_module
+```
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None      | N/A        | N/A                                 |
+

--- a/specs/012-scripting-context/quickstart.md
+++ b/specs/012-scripting-context/quickstart.md
@@ -39,7 +39,7 @@ CREATE TRIGGER ensure_audit
     FOR EACH ROW
     LANGUAGE rhai
 AS '
-    if oxibase.ctx.old.quantity != oxibase.ctx.new.quantity {
+    if oxibase.ctx["old"].quantity != oxibase.ctx["new"].quantity {
         oxibase::execute("INSERT INTO log ...");
     }
 ';

--- a/specs/012-scripting-context/quickstart.md
+++ b/specs/012-scripting-context/quickstart.md
@@ -1,0 +1,46 @@
+# Quickstart: Using the New Trigger Context API
+
+Triggers in Oxibase now expose their row data under the `oxibase.ctx` object instead of using global `OLD` and `NEW` variables.
+
+## Python
+
+```python
+CREATE TRIGGER prevent_negative
+    BEFORE UPDATE ON accounts
+    FOR EACH ROW
+    LANGUAGE python
+AS '
+import oxibase
+
+if oxibase.ctx.new["balance"] < 0:
+    # Mutating the proxy saves to the DB automatically
+    oxibase.ctx.new["balance"] = 0
+';
+```
+
+## JavaScript (Boa)
+
+```javascript
+CREATE TRIGGER uppercase_name
+    BEFORE INSERT ON users
+    FOR EACH ROW
+    LANGUAGE js
+AS '
+    // Mutate the string directly
+    oxibase.ctx.new.name = oxibase.ctx.new.name.toUpperCase();
+';
+```
+
+## Rhai
+
+```rust
+CREATE TRIGGER ensure_audit
+    AFTER UPDATE ON inventory
+    FOR EACH ROW
+    LANGUAGE rhai
+AS '
+    if oxibase.ctx.old.quantity != oxibase.ctx.new.quantity {
+        oxibase::execute("INSERT INTO log ...");
+    }
+';
+```

--- a/specs/012-scripting-context/spec.md
+++ b/specs/012-scripting-context/spec.md
@@ -1,0 +1,79 @@
+# Feature Specification: Scripting Backend Context Refactor (oxibase.ctx)
+
+**Feature Branch**: `012-scripting-context`  
+**Created**: May 13 2026  
+**Status**: Draft  
+**Input**: "in javascript, exposing OLD, and NEW looks off, same as in JS. can you think of a more 'natural' way ? maybe somethign like import oxibase; oxibase.ctx.new; oxibase.ctx.old; similar with JS ?"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Python Context Refactor (Priority: P1)
+
+Developers writing triggers in Python need an idiomatic way to access trigger context rather than relying on magically injected global variables, which pollute the namespace and feel unnatural.
+
+**Why this priority**: Python is a core scripting backend and heavily utilized for triggers.
+
+**Independent Test**: Can be fully tested by updating the Python trigger integration tests in `tests/triggers_test.rs` to use `oxibase.ctx.old` and `oxibase.ctx.new`, ensuring data validation and transformation still work correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Python `BEFORE UPDATE` trigger using `oxibase.ctx.new`, **When** the trigger mutates the new row via `oxibase.ctx.new["balance"] = 100`, **Then** the updated value is successfully extracted and saved to the database.
+2. **Given** a Python `AFTER UPDATE` trigger, **When** the script accesses `oxibase.ctx.old["id"]`, **Then** it correctly resolves the integer ID of the record before the update.
+
+---
+
+### User Story 2 - JavaScript Context Refactor (Priority: P1)
+
+Developers writing triggers in JavaScript need an idiomatic way to access trigger context rather than relying on magically injected global variables.
+
+**Why this priority**: JavaScript is a core scripting backend alongside Python.
+
+**Independent Test**: Can be fully tested by updating the JS trigger integration tests in `tests/triggers_test.rs`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a JavaScript `BEFORE UPDATE` trigger, **When** the script mutates `oxibase.ctx.new.balance = 100`, **Then** the updated value is correctly saved to the database.
+2. **Given** a JavaScript `AFTER UPDATE` trigger, **When** the script accesses `oxibase.ctx.old.balance`, **Then** it successfully retrieves the balance value from the previous state.
+
+---
+
+### User Story 3 - Rhai Context Refactor (Priority: P2)
+
+Developers writing triggers in Rhai should use the same idiomatic `oxibase.ctx` API as Python and JS for consistency across the engine, removing the `OLD` and `NEW` global variables from the evaluation scope.
+
+**Why this priority**: Rhai is the default, embedded scripting engine. It must remain feature-parity consistent with JS and Python.
+
+**Independent Test**: Can be fully tested by updating the Rhai trigger tests in `tests/triggers_test.rs`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Rhai `BEFORE INSERT` trigger, **When** it modifies `oxibase.ctx.new.name`, **Then** the Rhai dynamic proxy mutates the underlying memory correctly and persists to storage.
+
+### Edge Cases
+
+- What happens if the trigger explicitly attempts to reassign the entire `ctx` or `new` object instead of its properties (e.g., `oxibase.ctx.new = {"foo": 1}`)? 
+  - *Mitigation*: The engine extraction phase must safely ignore this or fail gracefully, as it expects to extract fields by iterating the known table schema against the root `new` dictionary.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Python scripting backend MUST inject an `oxibase` module containing a `ctx` object, which in turn houses `old` and `new` row dictionaries.
+- **FR-002**: The Boa scripting backend MUST inject a global `oxibase` object containing a `ctx` object, which houses the `old` and `new` JS objects.
+- **FR-003**: The Rhai scripting backend MUST inject an `oxibase` Map containing a `ctx` Map, which exposes the `OldRowProxy` and `NewRowProxy`.
+- **FR-004**: System MUST NOT inject `OLD` and `NEW` directly into the global execution scope for any of the backends.
+- **FR-005**: Trigger `new` row extraction logic MUST read from the deeply nested `oxibase.ctx.new` path instead of the global namespace.
+- **FR-006**: All embedded tutorial markdown examples and Rust integration tests MUST be updated to utilize the new syntax.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Passes all modified triggers tests via `cargo nextest run --features js,python --test triggers_test`.
+- **SC-002**: Passes the tutorial compilation test via `cargo nextest run --features js,python --test tutorial_triggers_test`.
+- **SC-003**: Passes `make lint` without warnings, ensuring no dead code remains from the legacy `OLD`/`NEW` extraction paths.
+
+## Assumptions
+
+- **Assumption**: Breaking existing trigger code is acceptable and intended for this release.
+- **Assumption**: The underlying proxy memory implementations (`NewRowProxy`, PyDicts, JS Objects) do not require architectural changes; only their scoping/injection paths require modification.

--- a/specs/012-scripting-context/tasks.md
+++ b/specs/012-scripting-context/tasks.md
@@ -1,0 +1,82 @@
+# Tasks: Scripting Backend Context Refactor (oxibase.ctx)
+
+**Input**: Design documents from `specs/012-scripting-context/`
+**Prerequisites**: plan.md, spec.md, contracts/, quickstart.md
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- `src/functions/backends/` for all scripting backend modification
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Update tests and tutorials to map to the new target syntax
+
+- [ ] T001 Update `docs/_docs/tutorials/triggers.md` tutorial with the new `oxibase.ctx.old` and `oxibase.ctx.new` syntax across all languages.
+- [ ] T002 Update tutorial integration test `tests/tutorial_triggers_test.rs` to use the new `oxibase.ctx` syntax.
+
+---
+
+## Phase 2: User Story 1 - Python Context Refactor (Priority: P1) 🎯 MVP
+
+**Goal**: Encapsulate `OLD` and `NEW` inside `oxibase.ctx.old` and `oxibase.ctx.new` for Python scripts.
+
+**Independent Test**: `tests/triggers_test.rs` (Python triggers block)
+
+### Implementation for User Story 1
+
+- [ ] T003 [P] [US1] Update `src/functions/backends/python.rs` to inject a `ctx` Python dictionary containing `old` and `new` into the `oxibase` module, rather than putting `OLD` and `NEW` directly into the scope.
+- [ ] T004 [P] [US1] Update `src/functions/backends/python.rs` `extract_new_row_dict` logic to read the updated row state from `vm.sys_modules["oxibase"].ctx.new`.
+- [ ] T005 [P] [US1] Update all Python trigger tests in `tests/triggers_test.rs` to use the `oxibase.ctx` syntax.
+- [ ] T006 [US1] Run `cargo nextest run --features python --test triggers_test` and fix any Python trigger execution failures.
+
+**Checkpoint**: Python triggers can correctly run context properties nested inside the module.
+
+---
+
+## Phase 3: User Story 2 - JavaScript Context Refactor (Priority: P1)
+
+**Goal**: Encapsulate `OLD` and `NEW` inside `oxibase.ctx.old` and `oxibase.ctx.new` for JS (Boa) scripts.
+
+**Independent Test**: `tests/triggers_test.rs` (JS triggers block)
+
+### Implementation for User Story 2
+
+- [ ] T007 [P] [US2] Update `src/functions/backends/boa.rs` to create a `ctx` property inside the global `oxibase` object containing `old` and `new` JS objects. Remove the global `OLD`/`NEW` properties.
+- [ ] T008 [P] [US2] Update `src/functions/backends/boa.rs` `extract_new_row_json` logic to fetch the updated state from `context.global_object().get("oxibase").get("ctx").get("new")`.
+- [ ] T009 [P] [US2] Update all JavaScript trigger tests in `tests/triggers_test.rs` to use the `oxibase.ctx` syntax.
+- [ ] T010 [US2] Run `cargo nextest run --features js --test triggers_test` and fix any JS trigger execution failures.
+
+**Checkpoint**: JS triggers can correctly execute under the nested global properties.
+
+---
+
+## Phase 4: User Story 3 - Rhai Context Refactor (Priority: P2)
+
+**Goal**: Encapsulate `OLD` and `NEW` inside `oxibase.ctx.old` and `oxibase.ctx.new` for Rhai scripts.
+
+**Independent Test**: `tests/triggers_test.rs` (Rhai triggers block)
+
+### Implementation for User Story 3
+
+- [ ] T011 [P] [US3] Update `src/functions/backends/rhai.rs` to map `NewRowProxy` and `OldRowProxy` into an `oxibase` -> `ctx` Map structure within the evaluation scope.
+- [ ] T012 [P] [US3] Update all Rhai trigger tests in `tests/triggers_test.rs` to use the `oxibase.ctx` syntax.
+- [ ] T013 [US3] Run `cargo nextest run --test triggers_test` and fix any Rhai trigger execution failures.
+
+**Checkpoint**: Rhai triggers correctly bind the row proxies into a dynamic object.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: System-wide regression verification
+
+- [ ] T014 Run `cargo nextest run --features js,python` to verify all integrations operate without breaking existing systems.
+- [ ] T015 Run `make lint` and fix any unused variables or imports caused by removing the global `OLD` / `NEW` injection logic.

--- a/specs/012-scripting-context/tasks.md
+++ b/specs/012-scripting-context/tasks.md
@@ -19,8 +19,8 @@
 
 **Purpose**: Update tests and tutorials to map to the new target syntax
 
-- [ ] T001 Update `docs/_docs/tutorials/triggers.md` tutorial with the new `oxibase.ctx.old` and `oxibase.ctx.new` syntax across all languages.
-- [ ] T002 Update tutorial integration test `tests/tutorial_triggers_test.rs` to use the new `oxibase.ctx` syntax.
+- [x] T001 Update `docs/_docs/tutorials/triggers.md` tutorial with the new `oxibase.ctx.old` and `oxibase.ctx.new` syntax across all languages.
+- [x] T002 Update tutorial integration test `tests/tutorial_triggers_test.rs` to use the new `oxibase.ctx` syntax.
 
 ---
 
@@ -32,10 +32,10 @@
 
 ### Implementation for User Story 1
 
-- [ ] T003 [P] [US1] Update `src/functions/backends/python.rs` to inject a `ctx` Python dictionary containing `old` and `new` into the `oxibase` module, rather than putting `OLD` and `NEW` directly into the scope.
-- [ ] T004 [P] [US1] Update `src/functions/backends/python.rs` `extract_new_row_dict` logic to read the updated row state from `vm.sys_modules["oxibase"].ctx.new`.
-- [ ] T005 [P] [US1] Update all Python trigger tests in `tests/triggers_test.rs` to use the `oxibase.ctx` syntax.
-- [ ] T006 [US1] Run `cargo nextest run --features python --test triggers_test` and fix any Python trigger execution failures.
+- [x] T003 [P] [US1] Update `src/functions/backends/python.rs` to inject a `ctx` Python dictionary containing `old` and `new` into the `oxibase` module, rather than putting `OLD` and `NEW` directly into the scope.
+- [x] T004 [P] [US1] Update `src/functions/backends/python.rs` `extract_new_row_dict` logic to read the updated row state from `vm.sys_modules["oxibase"].ctx.new`.
+- [x] T005 [P] [US1] Update all Python trigger tests in `tests/triggers_test.rs` to use the `oxibase.ctx` syntax.
+- [x] T006 [US1] Run `cargo nextest run --features python --test triggers_test` and fix any Python trigger execution failures.
 
 **Checkpoint**: Python triggers can correctly run context properties nested inside the module.
 
@@ -49,10 +49,10 @@
 
 ### Implementation for User Story 2
 
-- [ ] T007 [P] [US2] Update `src/functions/backends/boa.rs` to create a `ctx` property inside the global `oxibase` object containing `old` and `new` JS objects. Remove the global `OLD`/`NEW` properties.
-- [ ] T008 [P] [US2] Update `src/functions/backends/boa.rs` `extract_new_row_json` logic to fetch the updated state from `context.global_object().get("oxibase").get("ctx").get("new")`.
-- [ ] T009 [P] [US2] Update all JavaScript trigger tests in `tests/triggers_test.rs` to use the `oxibase.ctx` syntax.
-- [ ] T010 [US2] Run `cargo nextest run --features js --test triggers_test` and fix any JS trigger execution failures.
+- [x] T007 [P] [US2] Update `src/functions/backends/boa.rs` to create a `ctx` property inside the global `oxibase` object containing `old` and `new` JS objects. Remove the global `OLD`/`NEW` properties.
+- [x] T008 [P] [US2] Update `src/functions/backends/boa.rs` `extract_new_row_json` logic to fetch the updated state from `context.global_object().get("oxibase").get("ctx").get("new")`.
+- [x] T009 [P] [US2] Update all JavaScript trigger tests in `tests/triggers_test.rs` to use the `oxibase.ctx` syntax.
+- [x] T010 [US2] Run `cargo nextest run --features js --test triggers_test` and fix any JS trigger execution failures.
 
 **Checkpoint**: JS triggers can correctly execute under the nested global properties.
 
@@ -66,9 +66,9 @@
 
 ### Implementation for User Story 3
 
-- [ ] T011 [P] [US3] Update `src/functions/backends/rhai.rs` to map `NewRowProxy` and `OldRowProxy` into an `oxibase` -> `ctx` Map structure within the evaluation scope.
-- [ ] T012 [P] [US3] Update all Rhai trigger tests in `tests/triggers_test.rs` to use the `oxibase.ctx` syntax.
-- [ ] T013 [US3] Run `cargo nextest run --test triggers_test` and fix any Rhai trigger execution failures.
+- [x] T011 [P] [US3] Update `src/functions/backends/rhai.rs` to map `NewRowProxy` and `OldRowProxy` into an `oxibase` -> `ctx` Map structure within the evaluation scope.
+- [x] T012 [P] [US3] Update all Rhai trigger tests in `tests/triggers_test.rs` to use the `oxibase.ctx` syntax.
+- [x] T013 [US3] Run `cargo nextest run --test triggers_test` and fix any Rhai trigger execution failures.
 
 **Checkpoint**: Rhai triggers correctly bind the row proxies into a dynamic object.
 
@@ -78,5 +78,5 @@
 
 **Purpose**: System-wide regression verification
 
-- [ ] T014 Run `cargo nextest run --features js,python` to verify all integrations operate without breaking existing systems.
-- [ ] T015 Run `make lint` and fix any unused variables or imports caused by removing the global `OLD` / `NEW` injection logic.
+- [x] T014 Run `cargo nextest run --features js,python` to verify all integrations operate without breaking existing systems.
+- [x] T015 Run `make lint` and fix any unused variables or imports caused by removing the global `OLD` / `NEW` injection logic.

--- a/src/functions/backends/boa.rs
+++ b/src/functions/backends/boa.rs
@@ -323,21 +323,28 @@ impl ScriptingBackend for BoaBackend {
     ) -> Result<()> {
         let mut context = create_secure_context();
 
-        if let Some(new_obj) = self.build_new_row_json(&mut context) {
-            let _ = context.register_global_property(
-                boa_engine::JsString::from("NEW"),
+        let new_obj_opt = self.build_new_row_json(&mut context);
+        let old_obj_opt = self.build_old_row_json(&mut context);
+
+        let mut ctx_initializer = boa_engine::object::ObjectInitializer::new(&mut context);
+
+        if let Some(new_obj) = new_obj_opt {
+            ctx_initializer.property(
+                boa_engine::JsString::from("new"),
                 new_obj,
-                Default::default(),
+                boa_engine::property::Attribute::all(),
             );
         }
 
-        if let Some(old_obj) = self.build_old_row_json(&mut context) {
-            let _ = context.register_global_property(
-                boa_engine::JsString::from("OLD"),
+        if let Some(old_obj) = old_obj_opt {
+            ctx_initializer.property(
+                boa_engine::JsString::from("old"),
                 old_obj,
-                Default::default(),
+                boa_engine::property::Attribute::all(),
             );
         }
+
+        let ctx_obj = ctx_initializer.build();
 
         let commit_fn = boa_engine::object::FunctionObjectBuilder::new(
             context.realm(),
@@ -394,6 +401,11 @@ impl ScriptingBackend for BoaBackend {
             .map_err(|e| Error::internal(format!("Failed to register JS begin: {}", e)))?;
 
         let oxibase_obj = boa_engine::object::ObjectInitializer::new(&mut context)
+            .property(
+                boa_engine::JsString::from("ctx"),
+                ctx_obj,
+                boa_engine::property::Attribute::all(),
+            )
             .function(
                 boa_engine::NativeFunction::from_fn_ptr(|_this, args, _ctx| {
                     let sql = args
@@ -469,10 +481,23 @@ impl ScriptingBackend for BoaBackend {
 
                 if let Ok(js_val) = context
                     .global_object()
-                    .get(boa_engine::JsString::from("NEW"), &mut context)
+                    .get(boa_engine::JsString::from("oxibase"), &mut context)
                 {
-                    if let Some(obj) = js_val.as_object() {
-                        let _ = self.extract_new_row_json(obj.clone(), &mut context);
+                    if let Some(oxibase) = js_val.as_object() {
+                        if let Ok(ctx_val) =
+                            oxibase.get(boa_engine::JsString::from("ctx"), &mut context)
+                        {
+                            if let Some(ctx) = ctx_val.as_object() {
+                                if let Ok(new_val) =
+                                    ctx.get(boa_engine::JsString::from("new"), &mut context)
+                                {
+                                    if let Some(obj) = new_val.as_object() {
+                                        let _ =
+                                            self.extract_new_row_json(obj.clone(), &mut context);
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
 

--- a/src/functions/backends/python.rs
+++ b/src/functions/backends/python.rs
@@ -341,20 +341,31 @@ impl ScriptingBackend for PythonBackend {
             .enter(|vm| {
                 let scope = vm.new_scope_with_builtins();
 
-                crate::functions::backends::triggers::CURRENT_NEW_ROW.with(|r| {
-                    if r.borrow().is_some() {
-                        if let Ok(dict) = self.build_new_row_dict(vm) {
-                            let _ = scope.globals.set_item("NEW", dict.into(), vm);
+                let mut oxibase_mod_opt = None;
+                if let Ok(m) = vm.import("oxibase", 0) {
+                    oxibase_mod_opt = Some(m);
+                }
+
+                if let Some(oxibase_mod) = oxibase_mod_opt {
+                    let ctx_ns = rustpython_vm::builtins::PyNamespace::new_ref(&vm.ctx);
+                    crate::functions::backends::triggers::CURRENT_NEW_ROW.with(|r| {
+                        if r.borrow().is_some() {
+                            if let Ok(dict) = self.build_new_row_dict(vm) {
+                                use rustpython_vm::AsObject;
+                                let _ = ctx_ns.as_object().set_attr("new", vm.new_pyobj(dict), vm);
+                            }
                         }
-                    }
-                });
-                crate::functions::backends::triggers::CURRENT_OLD_ROW.with(|r| {
-                    if r.borrow().is_some() {
-                        if let Ok(dict) = self.build_old_row_dict(vm) {
-                            let _ = scope.globals.set_item("OLD", dict.into(), vm);
+                    });
+                    crate::functions::backends::triggers::CURRENT_OLD_ROW.with(|r| {
+                        if r.borrow().is_some() {
+                            if let Ok(dict) = self.build_old_row_dict(vm) {
+                                use rustpython_vm::AsObject;
+                                let _ = ctx_ns.as_object().set_attr("old", vm.new_pyobj(dict), vm);
+                            }
                         }
-                    }
-                });
+                    });
+                    let _ = oxibase_mod.set_attr("ctx", vm.new_pyobj(ctx_ns), vm);
+                }
 
                 for (i, arg) in args.iter().enumerate() {
                     let param_name = param_names[i];
@@ -390,14 +401,20 @@ impl ScriptingBackend for PythonBackend {
 
                                 crate::functions::backends::triggers::CURRENT_NEW_ROW.with(|r| {
                                     if r.borrow().is_some() {
-                                        if let Ok(Some(py_val)) =
-                                            scope.globals.get_item_opt("NEW", vm)
-                                        {
-                                            if let Ok(dict) =
-                                                py_val.downcast::<rustpython_vm::builtins::PyDict>()
-                                            {
-                                                let _ = self.extract_new_row_dict(dict, vm);
+                                        let mut new_row_extracted = false;
+                                        if let Ok(oxibase_mod) = vm.import("oxibase", 0) {
+                                            if let Ok(ctx_obj) = oxibase_mod.get_attr("ctx", vm) {
+                                                if let Ok(new_obj) = ctx_obj.get_attr("new", vm) {
+                                                    if let Ok(dict) = new_obj.downcast::<rustpython_vm::builtins::PyDict>() {
+                                                        let _ = self.extract_new_row_dict(dict, vm);
+                                                        new_row_extracted = true;
+                                                    }
+                                                }
                                             }
+                                        }
+                                        if !new_row_extracted {
+                                            // Fallback for scope extraction if needed?
+                                            // Actually, FR-005 mandates reading from the nested path.
                                         }
                                     }
                                 });

--- a/src/functions/backends/rhai.rs
+++ b/src/functions/backends/rhai.rs
@@ -130,16 +130,20 @@ impl ScriptingBackend for RhaiBackend {
     fn execute(&self, code: &str, args: &[Value], param_names: &[&str]) -> Result<Value> {
         let mut scope = Scope::new();
 
+        let mut ctx_map = rhai::Map::new();
         crate::functions::backends::triggers::CURRENT_NEW_ROW.with(|r| {
             if r.borrow().is_some() {
-                scope.push("NEW", NewRowProxy);
+                ctx_map.insert("new".into(), rhai::Dynamic::from(NewRowProxy));
             }
         });
         crate::functions::backends::triggers::CURRENT_OLD_ROW.with(|r| {
             if r.borrow().is_some() {
-                scope.push("OLD", OldRowProxy);
+                ctx_map.insert("old".into(), rhai::Dynamic::from(OldRowProxy));
             }
         });
+        let mut oxibase_map = rhai::Map::new();
+        oxibase_map.insert("ctx".into(), rhai::Dynamic::from(ctx_map));
+        scope.push("oxibase", oxibase_map);
 
         // Create arguments array for compatibility
         let mut args_array = rhai::Array::new();
@@ -208,16 +212,20 @@ impl ScriptingBackend for RhaiBackend {
     ) -> Result<()> {
         let mut scope = Scope::new();
 
+        let mut ctx_map = rhai::Map::new();
         crate::functions::backends::triggers::CURRENT_NEW_ROW.with(|r| {
             if r.borrow().is_some() {
-                scope.push("NEW", NewRowProxy);
+                ctx_map.insert("new".into(), rhai::Dynamic::from(NewRowProxy));
             }
         });
         crate::functions::backends::triggers::CURRENT_OLD_ROW.with(|r| {
             if r.borrow().is_some() {
-                scope.push("OLD", OldRowProxy);
+                ctx_map.insert("old".into(), rhai::Dynamic::from(OldRowProxy));
             }
         });
+        let mut oxibase_map = rhai::Map::new();
+        oxibase_map.insert("ctx".into(), rhai::Dynamic::from(ctx_map));
+        scope.push("oxibase", oxibase_map);
 
         // Bind arguments to scope using parameter names
         for (i, arg) in args.iter().enumerate() {

--- a/tests/triggers_test.rs
+++ b/tests/triggers_test.rs
@@ -38,7 +38,7 @@ fn test_create_and_drop_trigger() {
         FOR EACH ROW
         LANGUAGE rhai
         AS '
-            if NEW.id < 0 {
+            if oxibase.ctx["new"].id < 0 {
                 throw "Negative ID not allowed";
             }
         ';
@@ -82,7 +82,7 @@ fn test_data_transformation_trigger() {
         FOR EACH ROW
         LANGUAGE rhai
         AS '
-            NEW.name = "PREFIX_" + NEW.name;
+            oxibase.ctx["new"].name = "PREFIX_" + oxibase.ctx["new"].name;
         ';
     "#,
         )
@@ -115,8 +115,8 @@ fn test_audit_trigger() {
         FOR EACH ROW
         LANGUAGE rhai
         AS '
-            if OLD.price != NEW.price {
-                oxibase::execute("INSERT INTO audit_log (product_id, old_price, new_price) VALUES (" + OLD.id + ", " + OLD.price + ", " + NEW.price + ")");
+            if oxibase.ctx["old"].price != oxibase.ctx["new"].price {
+                oxibase::execute("INSERT INTO audit_log (product_id, old_price, new_price) VALUES (" + oxibase.ctx["old"].id + ", " + oxibase.ctx["old"].price + ", " + oxibase.ctx["new"].price + ")");
             }
         ';
     "#).unwrap();
@@ -156,7 +156,9 @@ fn test_python_trigger() {
         FOR EACH ROW
         LANGUAGE python
         AS '
-if NEW["balance"] < 0:
+import oxibase
+
+if oxibase.ctx.new["balance"] < 0:
     raise RuntimeError("Negative balance not allowed")
 '
     "#,
@@ -172,6 +174,7 @@ if NEW["balance"] < 0:
     let insert_err = executor.execute("INSERT INTO accounts (id, balance) VALUES (1, -50.0)");
     assert!(insert_err.is_err());
     if let Err(e) = insert_err {
+        println!("Error was: {:?}", e);
         assert!(e.to_string().contains("Negative balance not allowed"));
     }
 
@@ -188,7 +191,9 @@ if NEW["balance"] < 0:
         FOR EACH ROW
         LANGUAGE python
         AS '
-NEW["balance"] = NEW["balance"] + 10.0
+import oxibase
+
+oxibase.ctx.new["balance"] = oxibase.ctx.new["balance"] + 10.0
 '
     "#,
         )
@@ -223,9 +228,9 @@ fn test_js_trigger() {
         FOR EACH ROW
         LANGUAGE js
         AS '
-if (OLD.balance !== NEW.balance) {
-    let diff = NEW.balance - OLD.balance;
-    oxibase.execute("INSERT INTO audit_js (id, amount) VALUES (" + NEW.id + ", " + diff + ")");
+if (oxibase.ctx.old.balance !== oxibase.ctx.new.balance) {
+    let diff = oxibase.ctx.new.balance - oxibase.ctx.old.balance;
+    oxibase.execute("INSERT INTO audit_js (id, amount) VALUES (" + oxibase.ctx.new.id + ", " + diff + ")");
 }
 '
     "#,

--- a/tests/tutorial_triggers_test.rs
+++ b/tests/tutorial_triggers_test.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(any(feature = "js", feature = "python"))]
 use oxibase::core::Value;
 use oxibase::executor::Executor;
 use oxibase::storage::mvcc::engine::MVCCEngine;
@@ -24,7 +25,7 @@ fn setup_executor() -> Executor {
 }
 
 #[test]
-fn test_tutorial_triggers() {
+fn test_tutorial_triggers_rhai() {
     let executor = setup_executor();
 
     // Step 1: Validation in Rhai
@@ -64,6 +65,23 @@ fn test_tutorial_triggers() {
     assert!(res.is_err());
     let err_msg = res.err().unwrap().to_string();
     assert!(err_msg.contains("Account balance cannot be negative!"));
+}
+
+#[test]
+#[cfg(feature = "js")]
+fn test_tutorial_triggers_js() {
+    let executor = setup_executor();
+
+    let res = executor.execute(
+        "CREATE TABLE accounts (
+            id INTEGER PRIMARY KEY,
+            owner_name TEXT,
+            balance FLOAT
+        );",
+    );
+    assert!(res.is_ok());
+    let _ = executor
+        .execute("INSERT INTO accounts (id, owner_name, balance) VALUES (1, 'Alice', 100.0);");
 
     // Step 2: Transformation in JS
     let res = executor.execute(
@@ -88,6 +106,23 @@ fn test_tutorial_triggers() {
         .unwrap();
     assert!(res.next());
     assert_eq!(res.row().get(0), Some(&Value::text("ALICE LOWERCASE")));
+}
+
+#[test]
+#[cfg(feature = "python")]
+fn test_tutorial_triggers_python() {
+    let executor = setup_executor();
+
+    let res = executor.execute(
+        "CREATE TABLE accounts (
+            id INTEGER PRIMARY KEY,
+            owner_name TEXT,
+            balance FLOAT
+        );",
+    );
+    assert!(res.is_ok());
+    let _ = executor
+        .execute("INSERT INTO accounts (id, owner_name, balance) VALUES (1, 'Alice', 100.0);");
 
     // Step 3: Audit Logging in Python
     let res = executor.execute(

--- a/tests/tutorial_triggers_test.rs
+++ b/tests/tutorial_triggers_test.rs
@@ -1,0 +1,144 @@
+// Copyright 2026 Oxibase Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use oxibase::core::Value;
+use oxibase::executor::Executor;
+use oxibase::storage::mvcc::engine::MVCCEngine;
+use std::sync::Arc;
+
+fn setup_executor() -> Executor {
+    let engine = MVCCEngine::in_memory();
+    engine.open_engine().unwrap();
+    Executor::new(Arc::new(engine))
+}
+
+#[test]
+fn test_tutorial_triggers() {
+    let executor = setup_executor();
+
+    // Step 1: Validation in Rhai
+    let res = executor.execute(
+        "CREATE TABLE accounts (
+            id INTEGER PRIMARY KEY,
+            owner_name TEXT,
+            balance FLOAT
+        );",
+    );
+    assert!(res.is_ok());
+
+    let res = executor.execute(
+        r#"
+        CREATE TRIGGER ensure_positive_balance
+            BEFORE INSERT ON accounts
+            FOR EACH ROW
+            LANGUAGE rhai
+        AS '
+            if oxibase.ctx["new"].balance < 0.0 {
+                throw "Account balance cannot be negative!";
+            }
+        ';
+        "#,
+    );
+    if let Err(e) = &res {
+        println!("Error creating Rhai trigger: {:?}", e);
+    }
+    assert!(res.is_ok());
+
+    let res = executor
+        .execute("INSERT INTO accounts (id, owner_name, balance) VALUES (1, 'Alice', 100.0);");
+    assert!(res.is_ok());
+
+    let res = executor
+        .execute("INSERT INTO accounts (id, owner_name, balance) VALUES (2, 'Bob', -50.0);");
+    assert!(res.is_err());
+    let err_msg = res.err().unwrap().to_string();
+    assert!(err_msg.contains("Account balance cannot be negative!"));
+
+    // Step 2: Transformation in JS
+    let res = executor.execute(
+        r#"
+        CREATE TRIGGER normalize_owner_name
+            BEFORE UPDATE ON accounts
+            FOR EACH ROW
+            LANGUAGE js
+        AS '
+            // Force the owner name to be uppercase before saving
+            oxibase.ctx.new.owner_name = oxibase.ctx.new.owner_name.toUpperCase();
+        ';
+        "#,
+    );
+    assert!(res.is_ok());
+
+    let res = executor.execute("UPDATE accounts SET owner_name = 'alice lowercase' WHERE id = 1;");
+    assert!(res.is_ok());
+
+    let mut res = executor
+        .execute("SELECT owner_name FROM accounts WHERE id = 1;")
+        .unwrap();
+    assert!(res.next());
+    assert_eq!(res.row().get(0), Some(&Value::text("ALICE LOWERCASE")));
+
+    // Step 3: Audit Logging in Python
+    let res = executor.execute(
+        "CREATE TABLE audit_log (
+            account_id INTEGER,
+            old_balance FLOAT,
+            new_balance FLOAT,
+            changed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );",
+    );
+    assert!(res.is_ok());
+
+    let res = executor.execute(
+        r#"
+        CREATE TRIGGER log_balance_changes
+            AFTER UPDATE ON accounts
+            FOR EACH ROW
+            LANGUAGE python
+        AS '
+import oxibase
+
+# Only log if the balance actually changed
+if oxibase.ctx.old["balance"] != oxibase.ctx.new["balance"]:
+    # Use oxibase.execute to run DML side-effects
+    stmt = "INSERT INTO audit_log (account_id, old_balance, new_balance) VALUES (" + str(oxibase.ctx.old["id"]) + ", " + str(oxibase.ctx.old["balance"]) + ", " + str(oxibase.ctx.new["balance"]) + ")"
+    oxibase.execute(stmt)
+';
+        "#
+    );
+    if let Err(e) = &res {
+        println!("Error creating Python trigger: {:?}", e);
+    }
+    assert!(res.is_ok());
+
+    // Perform an UPDATE that changes the balance
+    let res = executor.execute("UPDATE accounts SET balance = 150.0 WHERE id = 1;");
+    if let Err(e) = &res {
+        println!("Error executing UPDATE for Python trigger: {:?}", e);
+    }
+    assert!(res.is_ok());
+
+    // Query audit_log to assert logging happened
+    let mut res = executor
+        .execute("SELECT account_id, old_balance, new_balance FROM audit_log;")
+        .unwrap();
+    assert!(res.next());
+    assert_eq!(res.row().get(0), Some(&Value::Integer(1)));
+    assert_eq!(res.row().get(1), Some(&Value::Float(100.0)));
+    assert_eq!(res.row().get(2), Some(&Value::Float(150.0)));
+
+    // Step 4: Dropping
+    let res = executor.execute("DROP TRIGGER IF EXISTS log_balance_changes ON accounts;");
+    assert!(res.is_ok());
+}


### PR DESCRIPTION
## Summary
This pull request refactors the context injection for our embedded scripting backends (Python, Boa/JS, Rhai) when executing Event Triggers. Previously, `OLD` and `NEW` row proxies were injected directly into the global script namespace, which felt unnatural and polluted the global scope.

This refactor encapsulates these variables securely under the `oxibase.ctx` object (i.e. `oxibase.ctx.new` and `oxibase.ctx.old`), aligning with a more idiomatic and intentional execution environment design.

## Key Changes
- **Python**: Injects `ctx` as a `PyNamespace` attribute on the existing `oxibase` native module, storing the `new` and `old` dictionary proxies.
- **Boa (JS)**: Updates the global `oxibase` object instantiation to construct and assign a `ctx` JS object holding `new` and `old`.
- **Rhai**: Removes the direct proxy scope injection in favor of a dynamic `oxibase` Map enclosing `ctx`.
- Updates `tutorial_triggers_test.rs` and the tutorial documentation `docs/_docs/tutorials/triggers.md` to reflect the new syntax standards.