### PR TITLE
feat: implement DROP PROCEDURE statement

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory": "specs/018-public-schema-fallback"}
+{"feature_directory": "specs/019-drop-procedure"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,6 @@ The system is an autonomous relational database management system.
 - Binary artifacts are built for Linux, macOS, and Windows on release. Ensure any new dependencies support cross-compilation on these targets.
 
 <!-- SPECKIT START -->
-/Users/gabriel.maeztu/repos/oxibase/specs/018-public-schema-fallback/plan.md
+/Users/gabriel.maeztu/repos/oxibase/specs/019-drop-procedure/plan.md
 <!-- SPECKIT END -->
 

--- a/Makefile
+++ b/Makefile
@@ -78,3 +78,10 @@ run-files: build
 run-all:
 	cargo build --release --features js,python
 	./target/release/oxibase repl -d memory://
+
+# [run] Build and run oxibase with all backends (Rhai, JS, Python) file-based database
+run-all-files:
+	cargo build --release --features js,python
+	./target/release/oxibase repl -d file://./examples/oxibase.db
+
+

--- a/specs/019-drop-procedure/checklists/api.md
+++ b/specs/019-drop-procedure/checklists/api.md
@@ -1,0 +1,28 @@
+# Interface Contracts Quality Checklist: Drop Procedure
+
+**Purpose**: Validate interface requirements quality and completeness
+**Created**: 2026-05-16
+**Audience**: Reviewer (PR)
+**Strictness**: Rigorous
+**Feature**: [spec.md](../spec.md)
+
+## Syntax and Parsing Rules
+- [ ] CHK001 - Are the allowed identifier formats for `<procedure_name>` explicitly defined? [Completeness, Spec §3.1]
+- [ ] CHK002 - Is the position and optionality of the `IF EXISTS` clause clearly specified in the syntax grammar? [Clarity, Spec §3.2]
+- [ ] CHK003 - Does the specification define whether the statement supports schema-qualified names (e.g., `DROP PROCEDURE public.my_proc`)? [Coverage, Gap]
+- [ ] CHK004 - Are parsing requirements for whitespace and case-insensitivity of the keywords `DROP`, `PROCEDURE`, `IF`, `EXISTS` documented? [Completeness, Gap]
+
+## Execution Semantics
+- [ ] CHK005 - Is the exact sequence of catalog modifications upon a successful drop documented? [Completeness, Spec §3.4]
+- [ ] CHK006 - Does the spec define whether dropping a procedure automatically unregisters it from all active sessions/caches? [Coverage, Gap]
+- [ ] CHK007 - Are the specific standard error codes or error messages defined for the "object not found" case? [Clarity, Spec §3.5]
+- [ ] CHK008 - Is the fallback behavior (ignoring the error) for `IF EXISTS` explicitly defined in terms of system state changes? [Consistency, Spec §3.6]
+
+## Edge Cases and Dependencies
+- [ ] CHK009 - Are the requirements for dropping a procedure that is currently executing or in use defined? [Edge Case, Gap]
+- [ ] CHK010 - Is the behavior specified for dropping a procedure that has identical names across different schemas, if schema qualification is omitted? [Edge Case, Gap]
+- [ ] CHK011 - Does the spec explicitly state that dependency tracking is unsupported, meaning cascading drops or restricting drops due to dependencies (like views) is not required? [Coverage, Spec §6.1]
+
+## Measurability and Acceptance
+- [ ] CHK012 - Can the success of a procedure deletion be objectively verified using existing system catalog views or `SHOW` commands? [Measurability, Gap]
+- [ ] CHK013 - Are the integration test scenarios specified in enough detail (e.g., specific SQL statements) to serve as an executable contract? [Clarity, Spec §4.3]

--- a/specs/019-drop-procedure/checklists/requirements.md
+++ b/specs/019-drop-procedure/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Drop Procedure
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec looks solid and testable as written. Moving to next phase.

--- a/specs/019-drop-procedure/data-model.md
+++ b/specs/019-drop-procedure/data-model.md
@@ -1,0 +1,25 @@
+# Data Model: Drop Procedure
+
+## AST Additions (`src/parser/ast.rs`)
+
+### `DropProcedureStatement`
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub struct DropProcedureStatement {
+    pub token: Token,
+    pub procedure_name: FunctionName,
+    pub if_exists: bool,
+}
+```
+
+## Statement Enum (`src/parser/ast.rs`)
+Add the variant to `Statement`:
+```rust
+pub enum Statement {
+    // ...
+    DropProcedure(DropProcedureStatement),
+}
+```
+
+## AST Evaluation (`src/executor/ddl.rs`)
+The `DropProcedureStatement` needs to be processed by the `execute_drop_procedure` function, modifying the catalog similar to other DROP commands.

--- a/specs/019-drop-procedure/plan.md
+++ b/specs/019-drop-procedure/plan.md
@@ -1,0 +1,75 @@
+# Implementation Plan: [FEATURE]
+
+**Branch**: `019-drop-procedure` | **Date**: 2026-05-16 | **Spec**: [link](../spec.md)
+**Input**: Feature specification from `specs/019-drop-procedure/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Implementation of the `DROP PROCEDURE` SQL statement, allowing users to delete existing stored procedures from the database, optionally supporting `IF EXISTS` to ignore non-existent procedures silently.
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: Rust 1.85+ (expected for modern backend)
+**Primary Dependencies**: thiserror, anyhow, parking_lot, dashmap, tokio (if pg-server), rhai, boa_engine (js), rustpython-vm (python)
+**Testing**: cargo nextest (via `make test` / `make test-all`)
+**Target Platform**: Embedded Monolithic DB (Linux, macOS, Windows)
+**Performance Goals**: Zero-Copy Unikernel memory efficiency
+**Constraints**: No `unwrap()`, strict ACID compliance, MVCC logic required, must pass `make lint` and `make license`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **Mainframe Monolith**: Does this maintain the embedded/monolith architecture? (No new external microservices/APIs)
+- [x] **ACID & MVCC**: Does this change respect multi-version concurrency control and strict data integrity?
+- [x] **Memory Efficiency**: Does this avoid unnecessary allocations (e.g., `Vec` clones)?
+- [x] **Safe Rust**: Are errors properly propagated? (No `unwrap()`, `expect()`, `todo!()`, `unimplemented!()`, or unjustified `unsafe`)
+- [x] **Tests First**: Will this be covered by tests that can be verified via `cargo nextest`?
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── api/           # Public Database API
+├── core/          # Core types (Value, Row, Schema, Error)
+├── executor/      # Query execution engine
+├── functions/     # Built-in functions (scalar, aggregate, window)
+├── optimizer/     # Cost-based query optimizer
+├── parser/        # SQL parser (lexer, AST, parser)
+├── storage/       # Storage engine and MVCC
+└── bin/           # CLI binary
+tests/             # Integration tests
+```
+
+**Structure Decision**: This feature primarily impacts `src/parser/` for AST and parsing additions (`ast.rs` and `statements.rs`) and `src/executor/` for handling execution in DDL logic (`ddl.rs`).
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., Unsafe Code Used] | [Performance critical loop] | [Safe abstraction was measured to be X% slower in benchmark Y] |
+| [e.g., Memory Allocation] | [External library requirement] | [No zero-copy alternatives exist for dependency Z] |

--- a/specs/019-drop-procedure/quickstart.md
+++ b/specs/019-drop-procedure/quickstart.md
@@ -1,0 +1,18 @@
+# Quickstart: Drop Procedure
+
+## Usage Example
+
+```sql
+-- Create a procedure first
+CREATE PROCEDURE my_procedure (param1 INT)
+LANGUAGE SQL
+AS $$
+    -- Procedure logic
+$$;
+
+-- Drop the procedure
+DROP PROCEDURE my_procedure;
+
+-- Drop with IF EXISTS to avoid errors if it's already deleted
+DROP PROCEDURE IF EXISTS my_procedure;
+```

--- a/specs/019-drop-procedure/research.md
+++ b/specs/019-drop-procedure/research.md
@@ -1,0 +1,13 @@
+# Phase 0: Research & Clarifications
+
+## Topic 1: AST Structure for DROP PROCEDURE
+**Decision**: Create a `DropProcedureStatement` struct in `src/parser/ast.rs`.
+**Rationale**: Aligns with existing AST structures like `DropTableStatement` and `DropFunctionStatement`. It should contain the `name` (an `ObjectName` or `Identifier`) and an `if_exists` boolean flag.
+
+## Topic 2: Parser Integration
+**Decision**: Update `src/parser/statements.rs` to parse `DROP PROCEDURE [IF EXISTS] <name>`.
+**Rationale**: `DROP` statements are already handled in `parse_drop_statement()`. We will add a branch for `PROCEDURE` that calls a new `parse_drop_procedure_statement()` method.
+
+## Topic 3: Executor Implementation
+**Decision**: Add `execute_drop_procedure` in `src/executor/ddl.rs`.
+**Rationale**: The procedure definition is likely stored in the database's catalog or system tables (like `oxibase.procedures` or similar, depending on the engine). We need to verify how `execute_create_procedure` works to know how to remove it. We'll implement `execute_drop_procedure` to remove the procedure by name, handling `IF EXISTS` logic.

--- a/specs/019-drop-procedure/spec.md
+++ b/specs/019-drop-procedure/spec.md
@@ -1,0 +1,53 @@
+# Feature Specification: Drop Procedure
+
+**Short Name**: drop-procedure
+**Date**: 2026-05-16
+
+## 1. Feature Description
+
+Implementation of the `DROP PROCEDURE` SQL statement, allowing users to delete existing stored procedures from the database. Currently, users can create and call procedures but have no way to remove them without dropping and recreating the entire schema.
+
+## 2. User Scenarios & Testing
+
+### 2.1 Acceptance Scenarios
+1. **Basic Deletion:**
+   - User creates a stored procedure.
+   - User issues `DROP PROCEDURE my_procedure`.
+   - The procedure is successfully removed.
+   - Subsequent calls to `my_procedure` result in an error indicating the procedure does not exist.
+
+2. **Deletion with IF EXISTS:**
+   - User issues `DROP PROCEDURE IF EXISTS non_existent_procedure`.
+   - The statement executes successfully without returning an error.
+   - User issues `DROP PROCEDURE IF EXISTS existing_procedure`.
+   - The procedure is successfully removed without returning an error.
+
+### 2.2 Error and Edge Cases
+1. **Dropping Non-Existent Procedure (without IF EXISTS):**
+   - User issues `DROP PROCEDURE non_existent_procedure`.
+   - The system returns a clear error indicating the procedure was not found.
+
+## 3. Functional Requirements
+
+1. The SQL parser must recognize the `DROP PROCEDURE` syntax.
+2. The SQL parser must optionally accept `IF EXISTS` within the `DROP PROCEDURE` statement.
+3. The SQL abstract syntax tree (AST) must represent the `DROP PROCEDURE` statement.
+4. The execution engine must handle the parsed `DROP PROCEDURE` statement and remove the specified procedure from the database catalog/storage.
+5. Dropping a procedure that does not exist without the `IF EXISTS` clause must return a standard "object not found" error.
+6. Using `IF EXISTS` when the procedure does not exist must bypass the error and execute successfully.
+
+## 4. Success Criteria
+
+1. Users can successfully delete procedures using standard SQL syntax.
+2. Attempting to call a deleted procedure fails as expected.
+3. Integration tests verify that `CREATE`, `CALL`, and `DROP PROCEDURE` operations work together harmoniously.
+
+## 5. Key Entities
+
+- **Procedure:** The executable routine stored in the database.
+- **Statement:** The `DROP PROCEDURE` SQL command.
+
+## 6. Assumptions
+
+- Procedures do not currently support complex dependency tracking (e.g., if a view or another procedure depends on a procedure being dropped, the drop will still proceed). 
+- Procedure dropping uses standard permission checks existing in the execution engine.

--- a/specs/019-drop-procedure/tasks.md
+++ b/specs/019-drop-procedure/tasks.md
@@ -1,0 +1,34 @@
+# Implementation Tasks: Drop Procedure
+
+**Goal**: Implementation of the `DROP PROCEDURE` SQL statement, allowing users to delete existing stored procedures from the database, optionally supporting `IF EXISTS` to ignore non-existent procedures silently.
+
+## Phase 1: Setup
+*(No setup tasks needed as this builds directly on existing AST/Parser/Executor infrastructure.)*
+
+## Phase 2: Foundational
+*(No foundational dependencies required before US1.)*
+
+## Phase 3: Basic Deletion [US1]
+**Story Goal**: Users can successfully delete procedures using standard SQL syntax.
+**Independent Test Criteria**: Creating a procedure, then executing `DROP PROCEDURE my_proc` successfully removes the procedure, causing subsequent calls to fail. Dropping a non-existent procedure should throw an error.
+
+- [x] T001 [P] [US1] Add `DropProcedureStatement` struct to AST in `src/parser/ast.rs`
+- [x] T002 [P] [US1] Add `DropProcedure(DropProcedureStatement)` to `Statement` enum in `src/parser/ast.rs`
+- [x] T003 [US1] Implement parsing for `DROP PROCEDURE` (handling `IF EXISTS`) in `src/parser/statements.rs`
+- [x] T004 [US1] Add parser routing logic for `DROP PROCEDURE` in `parse_drop_statement` in `src/parser/statements.rs`
+- [x] T005 [US1] Implement AST Display traits for `DropProcedureStatement` in `src/parser/ast.rs`
+- [x] T006 [P] [US1] Add `execute_drop_procedure` execution logic in `src/executor/ddl.rs`
+- [x] T007 [US1] Route `Statement::DropProcedure` to `execute_drop_procedure` in `src/executor/mod.rs`
+- [x] T008 [US1] Add integration tests in `tests/procedure_tests.rs` (or similar) verifying CREATE, DROP, and CALL behaviors.
+
+## Phase 4: Polish
+- [x] T009 Ensure clippy (`make lint`) passes with new AST and Executor code
+- [x] T010 Verify `make test` runs green for the new procedure tests
+
+---
+
+## Dependencies
+- **Phase 3 [US1]**: Basic Deletion depends on Phase 1 & 2 (Empty)
+
+## Implementation Strategy
+Start by implementing the AST modifications (T001, T002, T005). Once the AST supports the statement, move to the parser (T003, T004). Finally, connect the parsed statement to the execution engine (T006, T007) and add integration tests (T008) to prove it works as expected. All tasks are essentially part of a single flow, but T001/T002 and T006 can be initiated in parallel conceptually before bringing them together.

--- a/src/executor/ddl.rs
+++ b/src/executor/ddl.rs
@@ -1085,6 +1085,38 @@ impl Executor {
         Ok(())
     }
 
+    /// Delete a procedure from the system table
+    fn delete_procedure(&self, procedure_name: &str) -> Result<()> {
+        let mut tx = self.engine.begin_transaction()?;
+        let mut table = tx.get_table(SYS_PROCEDURES)?;
+
+        // Find the procedure ID by name
+        let mut scanner = table.scan(&[], None)?;
+        let mut procedure_id: Option<crate::core::value::Value> = None;
+
+        while scanner.next() {
+            let row = scanner.row();
+            if let Some(crate::core::value::Value::Text(name)) = row.get(2) {
+                if name.eq_ignore_ascii_case(procedure_name) {
+                    procedure_id = row.get(0).cloned(); // ID is at index 0
+                    break;
+                }
+            }
+        }
+
+        if let Some(id_value) = procedure_id {
+            // Delete by ID using WHERE expression
+            use crate::storage::expression::{ComparisonExpr, Expression as StorageExpr};
+            let mut id_expr = ComparisonExpr::new("id", crate::core::Operator::Eq, id_value);
+            let schema = table.schema();
+            id_expr.prepare_for_schema(schema);
+            table.delete(Some(&id_expr))?;
+        }
+
+        tx.commit()?;
+        Ok(())
+    }
+
     pub(crate) fn execute_create_procedure(
         &self,
         stmt: &crate::parser::ast::CreateProcedureStatement,
@@ -1141,6 +1173,33 @@ impl Executor {
 
         self.function_registry
             .register_procedure(&procedure_name_upper, stored_procedure);
+
+        Ok(Box::new(EmptyResult::new()))
+    }
+
+    /// Execute a DROP PROCEDURE statement
+    pub(crate) fn execute_drop_procedure(
+        &self,
+        stmt: &crate::parser::ast::DropProcedureStatement,
+        _ctx: &ExecutionContext,
+    ) -> Result<Box<dyn QueryResult>> {
+        let procedure_name = stmt.procedure_name.function();
+        let procedure_name_upper = procedure_name.to_uppercase();
+
+        // Check if procedure exists
+        if !self.procedure_exists(&procedure_name_upper)? {
+            if stmt.if_exists {
+                return Ok(Box::new(EmptyResult::new()));
+            }
+            return Err(Error::FunctionNotFound(procedure_name.clone()));
+        }
+
+        // Delete procedure from system table
+        self.delete_procedure(&procedure_name_upper)?;
+
+        // Unregister the procedure from the registry
+        self.function_registry
+            .unregister_procedure(&procedure_name_upper);
 
         Ok(Box::new(EmptyResult::new()))
     }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -892,6 +892,7 @@ impl Executor {
             Statement::CreateFunction(stmt) => self.execute_create_function(stmt, &ctx),
             Statement::DropFunction(stmt) => self.execute_drop_function(stmt, &ctx),
             Statement::CreateProcedure(stmt) => self.execute_create_procedure(stmt, &ctx),
+            Statement::DropProcedure(stmt) => self.execute_drop_procedure(stmt, &ctx),
             Statement::CreateTrigger(stmt) => self.execute_create_trigger(stmt, &ctx),
             Statement::DropTrigger(stmt) => self.execute_drop_trigger(stmt, &ctx),
             Statement::CreateSequence(stmt) => self.execute_create_sequence(stmt, &ctx),

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1329,6 +1329,7 @@ pub enum Statement {
     CreateFunction(CreateFunctionStatement),
     DropFunction(DropFunctionStatement),
     CreateProcedure(CreateProcedureStatement),
+    DropProcedure(DropProcedureStatement),
     CreateTrigger(CreateTriggerStatement),
     DropTrigger(DropTriggerStatement),
     CreateSchedule(CreateScheduleStatement),
@@ -1379,6 +1380,7 @@ impl fmt::Display for Statement {
             Statement::CreateFunction(s) => write!(f, "{}", s),
             Statement::DropFunction(s) => write!(f, "{}", s),
             Statement::CreateProcedure(s) => write!(f, "{}", s),
+            Statement::DropProcedure(s) => write!(f, "{}", s),
             Statement::CreateTrigger(s) => write!(f, "{}", s),
             Statement::DropTrigger(s) => write!(f, "{}", s),
             Statement::CreateSchedule(s) => write!(f, "{}", s),
@@ -2302,6 +2304,25 @@ impl fmt::Display for DropFunctionStatement {
             result.push_str("IF EXISTS ");
         }
         result.push_str(&self.function_name.to_string());
+        write!(f, "{}", result)
+    }
+}
+
+/// DROP PROCEDURE statement
+#[derive(Debug, Clone, PartialEq)]
+pub struct DropProcedureStatement {
+    pub token: Token,
+    pub procedure_name: FunctionName,
+    pub if_exists: bool,
+}
+
+impl fmt::Display for DropProcedureStatement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut result = String::from("DROP PROCEDURE ");
+        if self.if_exists {
+            result.push_str("IF EXISTS ");
+        }
+        result.push_str(&self.procedure_name.to_string());
         write!(f, "{}", result)
     }
 }

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -2334,9 +2334,13 @@ impl Parser {
             self.next_token();
             self.parse_drop_function_statement()
                 .map(Statement::DropFunction)
+        } else if self.peek_token_is_keyword("PROCEDURE") {
+            self.next_token();
+            self.parse_drop_procedure_statement()
+                .map(Statement::DropProcedure)
         } else {
             self.add_error(format!(
-                "expected TABLE, SCHEMA, INDEX, COLUMNAR INDEX, VIEW, or FUNCTION after DROP at {}",
+                "expected TABLE, SCHEMA, INDEX, COLUMNAR INDEX, VIEW, FUNCTION, or PROCEDURE after DROP at {}",
                 self.cur_token.position
             ));
             None
@@ -2414,6 +2418,31 @@ impl Parser {
         Some(DropFunctionStatement {
             token,
             function_name,
+            if_exists,
+        })
+    }
+
+    /// Parse a DROP PROCEDURE statement
+    fn parse_drop_procedure_statement(&mut self) -> Option<DropProcedureStatement> {
+        let token = self.cur_token.clone();
+
+        // Check for IF EXISTS
+        let if_exists = if self.peek_token_is_keyword("IF") {
+            self.next_token();
+            if !self.expect_keyword("EXISTS") {
+                return None;
+            }
+            true
+        } else {
+            false
+        };
+
+        // Parse procedure name (simple or qualified)
+        let procedure_name = self.parse_function_name()?;
+
+        Some(DropProcedureStatement {
+            token,
+            procedure_name,
             if_exists,
         })
     }

--- a/tests/procedure_tests.rs
+++ b/tests/procedure_tests.rs
@@ -2,6 +2,42 @@
 use oxibase::api::Database;
 
 #[test]
+fn test_drop_procedure() {
+    let db = Database::open_in_memory().unwrap();
+
+    let create_sql = r#"
+        CREATE PROCEDURE my_proc_to_drop() 
+        LANGUAGE rhai 
+        AS '
+            let a = 10; 
+        ';
+    "#;
+
+    let res = db.execute(create_sql, ());
+    assert!(res.is_ok(), "Failed to create procedure: {:?}", res.err());
+
+    // Call it to make sure it exists
+    let res = db.execute("CALL my_proc_to_drop();", ());
+    assert!(res.is_ok(), "Failed to call procedure: {:?}", res.err());
+
+    // Drop it
+    let res = db.execute("DROP PROCEDURE my_proc_to_drop;", ());
+    assert!(res.is_ok(), "Failed to drop procedure: {:?}", res.err());
+
+    // Call it again - should fail
+    let res = db.execute("CALL my_proc_to_drop();", ());
+    assert!(res.is_err(), "Procedure should not exist after drop");
+
+    // Drop it again - should fail
+    let res = db.execute("DROP PROCEDURE my_proc_to_drop;", ());
+    assert!(res.is_err(), "Procedure should not exist after drop");
+
+    // Drop it with IF EXISTS - should succeed
+    let res = db.execute("DROP PROCEDURE IF EXISTS my_proc_to_drop;", ());
+    assert!(res.is_ok(), "IF EXISTS should prevent error on drop");
+}
+
+#[test]
 fn test_create_and_call_procedure() {
     let db = Database::open_in_memory().unwrap();
 


### PR DESCRIPTION
## Summary
* Added `DropProcedureStatement` to the SQL AST
* Implemented parsing for `DROP PROCEDURE [IF EXISTS] <procedure_name>`
* Implemented `execute_drop_procedure` in the execution engine to remove procedures from the system catalog (`oxibase.procedures`) and unregister them from the function registry
* Added integration tests for creating, calling, and dropping procedures

This completes the `DROP PROCEDURE` feature implementation.