### PR TITLE
feat: implement FROM-first syntax support

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/029-opentelemetry-tracing"
+  "feature_directory": "specs/030-from-first-syntax"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,6 @@ The system is an autonomous relational database management system.
 - Binary artifacts are built for Linux, macOS, and Windows on release. Ensure any new dependencies support cross-compilation on these targets.
 
 <!-- SPECKIT START -->
-specs/029-opentelemetry-tracing/plan.md
+specs/030-from-first-syntax/plan.md
 <!-- SPECKIT END -->
 

--- a/specs/030-from-first-syntax/checklists/requirements.md
+++ b/specs/030-from-first-syntax/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: FROM-First Syntax
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/030-from-first-syntax/contracts/sql-grammar.md
+++ b/specs/030-from-first-syntax/contracts/sql-grammar.md
@@ -1,0 +1,30 @@
+# SQL Grammar Contract
+
+This document outlines the grammar changes introduced by the FROM-first syntax.
+
+## FROM-First Query Grammar
+
+The parser supports a new top-level statement structure that starts with the `FROM` keyword. 
+After the `FROM` keyword and table expression, any of the standard `SELECT` modifiers can follow in any order.
+
+```ebnf
+<from_first_statement> ::= "FROM" <table_expression> [ <from_clause_list> ]
+
+<from_clause_list> ::= <from_clause> [ <from_clause_list> ]
+
+<from_clause> ::= 
+    | "SELECT" [ "DISTINCT" ] <select_list>
+    | "WHERE" <expression>
+    | "GROUP BY" <group_by_list>
+    | "HAVING" <expression>
+    | "ORDER BY" <order_by_list>
+    | "LIMIT" <expression>
+    | "OFFSET" <expression> [ "ROWS" | "ROW" ]
+    | "WINDOW" <window_definition_list>
+
+```
+
+### Semantic Rules
+- If the `<from_clause_list>` does not contain a `"SELECT"` clause, the parser implicitly constructs a `"SELECT *"` projection.
+- Set operations (`UNION`, `INTERSECT`, `EXCEPT`) can be applied to `<from_first_statement>` blocks just like standard `<select_statement>` blocks.
+- The `table_expression` can be a table name, a subquery, a table function, or a `VALUES` clause, identical to standard `FROM` clauses.

--- a/specs/030-from-first-syntax/data-model.md
+++ b/specs/030-from-first-syntax/data-model.md
@@ -1,0 +1,18 @@
+# Data Model
+
+The FROM-First Syntax feature does not introduce new persistent data models or storage formats. It relies entirely on rewriting the Abstract Syntax Tree (AST) during the parsing phase.
+
+## AST Mapping
+
+- **Target Entity**: `SelectStatement` (defined in `src/parser/ast.rs`)
+- **Mapping rules for `FROM tbl` (without `SELECT`)**:
+  - `distinct`: `false`
+  - `columns`: `vec![Expression::Star(...)]`
+  - `table_expr`: `Some(Box::new(Expression::TableSource(...)))` for `tbl`
+  - Other clauses (`where_clause`, `group_by`, etc.): As parsed or default `None`/empty.
+
+- **Mapping rules for `FROM tbl SELECT x`**:
+  - `distinct`: Depends on if `DISTINCT` is present after `SELECT`
+  - `columns`: Parsed from the `SELECT` clause (e.g., `vec![x]`)
+  - `table_expr`: `Some(Box::new(Expression::TableSource(...)))` for `tbl`
+  - Other clauses (`where_clause`, `group_by`, etc.): As parsed or default `None`/empty.

--- a/specs/030-from-first-syntax/plan.md
+++ b/specs/030-from-first-syntax/plan.md
@@ -1,0 +1,59 @@
+# Implementation Plan: FROM-First Syntax
+
+**Branch**: `030-from-first-syntax` | **Date**: 2026-05-25 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/030-from-first-syntax/spec.md`
+
+## Summary
+
+Add support for DuckDB-style `FROM`-first queries to Oxibase. This allows the `FROM` clause to lead a statement, optionally followed by standard clauses like `SELECT`, `WHERE`, `ORDER BY`, etc., in any order. If `SELECT` is omitted, the parser will implicitly project `SELECT *`. The technical approach relies entirely on parser-level AST rewriting: the parser will produce a standard `SelectStatement` node for `FROM`-first queries, preventing any required changes to the logical planner, optimizer, or execution engine.
+
+## Technical Context
+
+**Language/Version**: Rust 1.85+ (expected for modern backend)
+**Primary Dependencies**: `thiserror`, `anyhow`
+**Testing**: `cargo nextest` (via `make test` / `make test-all`)
+**Target Platform**: Embedded Monolithic DB (Linux, macOS, Windows)
+**Performance Goals**: Zero-Copy Unikernel memory efficiency
+**Constraints**: No `unwrap()`, strict ACID compliance, MVCC logic required, must pass `make lint` and `make license`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **Mainframe Monolith**: Does this maintain the embedded/monolith architecture? (No new external microservices/APIs)
+- [x] **ACID & MVCC**: Does this change respect multi-version concurrency control and strict data integrity?
+- [x] **Memory Efficiency**: Does this avoid unnecessary allocations (e.g., `Vec` clones)?
+- [x] **Safe Rust**: Are errors properly propagated? (No `unwrap()`, `expect()`, `todo!()`, `unimplemented!()`, or unjustified `unsafe`)
+- [x] **Tests First**: Will this be covered by tests that can be verified via `cargo nextest`?
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/030-from-first-syntax/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (to be created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── parser/        # SQL parser (lexer, AST, parser) <-- Primary impact
+tests/             # Integration tests <-- New tests required
+```
+
+**Structure Decision**: The feature primarily impacts `src/parser/` (specifically `statements.rs` and potentially `ast.rs` if minor display adjustments are needed). Integration tests will be added to the test suite to verify AST construction and semantic equivalence.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None      | N/A        | N/A                                 |

--- a/specs/030-from-first-syntax/quickstart.md
+++ b/specs/030-from-first-syntax/quickstart.md
@@ -1,0 +1,53 @@
+# Quickstart: FROM-First Syntax
+
+Oxibase now supports DuckDB-style "FROM-first" syntax, allowing you to write queries that start with the `FROM` clause. This aligns the query structure with the logical flow of data (from source to projection) and provides a faster way to explore data.
+
+## Exploring Data (No SELECT)
+
+If you omit the `SELECT` clause, Oxibase automatically assumes `SELECT *`. This is the fastest way to quickly inspect a table:
+
+```sql
+-- Standard SQL
+SELECT * FROM users;
+
+-- FROM-first shorthand
+FROM users;
+```
+
+## Chaining Clauses
+
+You can add any standard clauses (`WHERE`, `ORDER BY`, `LIMIT`) after the `FROM` clause in any order:
+
+```sql
+-- Filter and order users
+FROM users WHERE age > 18 ORDER BY name LIMIT 10;
+```
+
+## Custom Projections (With SELECT)
+
+When you need specific columns, add the `SELECT` clause after the `FROM` clause.
+
+```sql
+-- Standard SQL
+SELECT id, email FROM users WHERE status = 'active';
+
+-- FROM-first
+FROM users WHERE status = 'active' SELECT id, email;
+-- or
+FROM users SELECT id, email WHERE status = 'active';
+```
+
+## Advanced Sources
+
+The syntax works with any valid `FROM` expression, including joins, table functions, and `VALUES` clauses:
+
+```sql
+-- Using table functions
+FROM generate_series(1, 5) AS s(num);
+
+-- Using JOINs
+FROM users u JOIN orders o ON u.id = o.user_id SELECT u.name, o.total;
+
+-- Using VALUES
+FROM (VALUES (1, 'Alice'), (2, 'Bob')) AS t(id, name);
+```

--- a/specs/030-from-first-syntax/research.md
+++ b/specs/030-from-first-syntax/research.md
@@ -1,0 +1,15 @@
+# Research: FROM-First Syntax
+
+## AST Representation
+- **Decision**: Reuse the existing `SelectStatement` AST node to represent FROM-first queries.
+- **Rationale**: The specification states that `FROM tbl SELECT ...` is semantically identical to `SELECT ... FROM tbl` (FR-004). By rewriting or mapping the FROM-first syntax directly into a `SelectStatement` with `columns` defaulting to `Expression::Star` (when SELECT is omitted), we avoid modifying the logical planner, optimizer, and execution engine entirely.
+- **Alternatives considered**: Creating a new `FromFirstStatement` AST node. This was rejected because it would require cascading changes throughout the entire optimizer and executor to handle the new node type, duplicating the logic of `SelectStatement`.
+
+## Parsing Strategy for "Any Order" Clauses
+- **Decision**: Implement a flexible clause parsing loop for `FROM`-first statements. When a statement begins with `FROM`, we will consume the table expression and then enter a loop that looks for keywords (`SELECT`, `WHERE`, `GROUP BY`, `ORDER BY`, `LIMIT`, `HAVING`, etc.) and parses them in whatever order they appear.
+- **Rationale**: The user clarified that clauses should be allowed in "Any order" after the initial `FROM`. The current `parse_select_statement` is strictly ordered (SELECT -> FROM -> WHERE -> GROUP BY ...). Building a new `parse_from_first_statement` function that builds up a `SelectStatement` handles this without breaking standard SQL parsing.
+- **Alternatives considered**: Modifying `parse_select_statement` to support any order. This was rejected as it could make the standard `SELECT` parser too lenient and incorrectly accept malformed standard SQL queries (e.g., `SELECT * WHERE x FROM tbl`).
+
+## Default Projection
+- **Decision**: When parsing a `FROM`-first statement, if no `SELECT` clause is encountered before the end of the statement, automatically populate the `columns` field of the resulting `SelectStatement` with a single `Expression::Star`.
+- **Rationale**: This fulfills the requirement that omitting `SELECT` is functionally equivalent to `SELECT *`.

--- a/specs/030-from-first-syntax/spec.md
+++ b/specs/030-from-first-syntax/spec.md
@@ -1,0 +1,77 @@
+# Feature Specification: FROM-First Syntax
+
+**Feature Branch**: `030-from-first-syntax`  
+**Created**: 2026-05-25  
+**Status**: Draft  
+**Input**: User description: "i would like to add a similar support to duckdb to the from clause: FROM-First Syntax DuckDB's SQL supports the FROM-first syntax..."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - FROM-First Syntax with a SELECT Clause (Priority: P1)
+
+Users should be able to write SQL queries where the `FROM` clause appears before the `SELECT` clause. This improves readability for queries with complex projections or when chaining operations, aligning with how data flows (source to projection).
+
+**Why this priority**: This is the core functionality requested. It introduces the new syntactic structure while keeping all existing query components (projection, source) explicit.
+
+**Independent Test**: Can be fully tested by a new integration test in the parser and executor suites verifying that `FROM table_name SELECT col1, col2` parses correctly and produces the same result set as `SELECT col1, col2 FROM table_name`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a table `tbl` with columns `i` and `s`, **When** the query `FROM tbl SELECT i, s;` is executed, **Then** the result set should contain columns `i` and `s` from `tbl`.
+2. **Given** a table `tbl` with columns `i` and `s`, **When** the query `FROM tbl SELECT *;` is executed, **Then** the result set should contain all columns from `tbl`.
+3. **Given** a complex query with subqueries like `FROM (VALUES ('a'), ('b')) t1(s), range(1, 3) t2(i) SELECT s, i;`, **When** the query is executed, **Then** the result set should match the equivalent standard `SELECT ... FROM ...` query.
+
+---
+
+### User Story 2 - FROM-First Syntax without a SELECT Clause (Priority: P2)
+
+Users should be able to write SQL queries starting with a `FROM` clause and completely omitting the `SELECT` clause. This acts as a shorthand for `SELECT * FROM ...`, making it quicker to inspect the entire contents of a table or relation.
+
+**Why this priority**: This is a direct consequence of supporting `FROM`-first syntax and provides a significant quality-of-life improvement for quick data exploration, matching the referenced DuckDB functionality.
+
+**Independent Test**: Can be fully tested by a new integration test verifying that `FROM table_name;` parses correctly and produces the same result set as `SELECT * FROM table_name;`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a table `tbl` with columns `i` and `s`, **When** the query `FROM tbl;` is executed, **Then** the result set should be identical to executing `SELECT * FROM tbl;`.
+2. **Given** a table-valued function or complex join in the `FROM` clause like `FROM (VALUES ('a'), ('b')) t1(s), range(1, 3) t2(i);`, **When** the query is executed, **Then** the result set should be identical to executing `SELECT * FROM (VALUES ('a'), ('b')) t1(s), range(1, 3) t2(i);`.
+
+---
+
+### Edge Cases
+
+- What happens when a `FROM` clause is followed by other clauses like `WHERE`, `GROUP BY`, `ORDER BY`, or `LIMIT` without a `SELECT` clause? (e.g., `FROM tbl WHERE i > 1;`)
+- What happens when a `FROM` clause is followed by a `SELECT` clause, and then other clauses? Is the order strict (`FROM` -> `SELECT` -> `WHERE` vs `FROM` -> `WHERE` -> `SELECT`)?
+- How does this interact with `UNION`, `INTERSECT`, and `EXCEPT`? (e.g., `FROM tbl1 UNION FROM tbl2;`)
+- How does the parser distinguish between a `FROM` clause acting as the main query block versus a `FROM` clause inside a subquery or `EXISTS` expression?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The SQL parser MUST successfully parse queries starting with the `FROM` keyword.
+- **FR-002**: The SQL parser MUST support an optional `SELECT` clause following a leading `FROM` clause.
+- **FR-003**: The SQL parser MUST implicitly add a `SELECT *` projection to the logical plan if a query starts with `FROM` and omits the `SELECT` clause.
+- **FR-004**: The optimizer and executor MUST treat `FROM tbl SELECT ...` and `SELECT ... FROM tbl` as semantically identical.
+- **FR-005**: The parser MUST support standard query clauses (`WHERE`, `GROUP BY`, `ORDER BY`, `LIMIT`, etc.) in conjunction with the `FROM`-first syntax, allowing these clauses to appear in any order following the initial `FROM` clause (e.g., `FROM tbl SELECT y WHERE x` or `FROM tbl WHERE x SELECT y`).
+- **FR-006**: The feature MUST be implemented without breaking existing standard SQL syntax (`SELECT ... FROM ...`).
+
+### Key Entities
+
+- **Parser/AST**: The Abstract Syntax Tree representation of a query must be updated to reflect that `SELECT` is optional and `FROM` can be the leading clause, or the parser rules must rewrite `FROM`-first queries into the standard AST representation during parsing.
+- **Logical Plan**: The logical plan generation must ensure that `FROM`-first queries produce identical logical plans to their standard SQL counterparts.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Passes all new parsing and execution tests for `FROM`-first syntax with and without `SELECT` clauses.
+- **SC-002**: Existing `make test` and `make test-all` suites pass completely without regressions (100% pass rate).
+- **SC-003**: Overall test coverage does not drop below the minimum threshold (`make coverage-check` passes).
+- **SC-004**: The code passes `make lint` with zero warnings and introduces no new `unwrap()` or `expect()` calls in library code.
+
+## Assumptions
+
+- The underlying execution engine does not need modification; the changes are entirely contained within the parser, AST construction, and potentially the initial logical plan building phases.
+- The `FROM`-first syntax should support all standard relations in the `FROM` clause, including base tables, views, subqueries, table functions, and joins.
+- The default behavior when `SELECT` is omitted is functionally equivalent to `SELECT *`.

--- a/specs/030-from-first-syntax/tasks.md
+++ b/specs/030-from-first-syntax/tasks.md
@@ -1,0 +1,81 @@
+# Tasks: FROM-First Syntax
+
+**Input**: Design documents from `specs/030-from-first-syntax/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: MUST include corresponding `cargo nextest` integration or unit tests for any new feature. 
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup
+
+**Purpose**: Project initialization and basic structure. No specific structural changes are required for this parser-only feature, but we establish the base parser files we will be editing.
+
+- [x] T001 Verify project compiles (`cargo build`)
+
+---
+
+## Phase 2: Foundational 
+
+**Purpose**: Blocking prerequisites that must be in place before the user stories can be fully realized.
+
+- [x] T002 Implement `parse_from_first_statement` function scaffold in `src/parser/statements.rs`.
+- [x] T003 Hook `parse_from_first_statement` into the main `parse_statement` dispatcher in `src/parser/statements.rs` when the `FROM` keyword is encountered.
+
+---
+
+## Phase 3: User Story 1 - FROM-First Syntax with a SELECT Clause (Priority: P1) 🎯 MVP
+
+**Goal**: Users should be able to write SQL queries where the `FROM` clause appears before the `SELECT` clause. The parser should accept these and rewrite them into a standard `SelectStatement` AST node.
+
+**Independent Test**: New tests in `src/parser/parser.rs` verifying `FROM table_name SELECT col1, col2` parses correctly into a `SelectStatement`.
+
+### Tests for User Story 1 ⚠️
+
+- [x] T010 [P] [US1] Add parser tests in `src/parser/parser.rs` to verify `FROM tbl SELECT a, b` parses equivalently to `SELECT a, b FROM tbl`.
+- [x] T011 [P] [US1] Add parser tests in `src/parser/parser.rs` for subqueries and complex FROM clauses with SELECT, e.g. `FROM (VALUES(1)) t(a) SELECT a`.
+- [x] T012 [P] [US1] Add parser tests in `src/parser/parser.rs` to verify that other clauses (`WHERE`, `ORDER BY`, `LIMIT`) can be parsed in "any order" alongside `SELECT` after `FROM`.
+- [x] T013 [US1] Implement the core logic of `parse_from_first_statement` in `src/parser/statements.rs`. It must loop to parse the initial table expression, then dynamically dispatch to parse `SELECT`, `WHERE`, `ORDER BY`, etc., based on keywords.
+- [x] T014 [US1] Ensure `parse_from_first_statement` properly constructs a `SelectStatement` struct and assigns the parsed clauses to their respective fields.
+- [x] T015 [US1] Run `make test` to verify the new parser tests pass.
+
+**Checkpoint**: At this point, User Story 1 should be fully functional, and explicit `FROM ... SELECT ...` queries should parse correctly.
+
+---
+
+## Phase 4: User Story 2 - FROM-First Syntax without a SELECT Clause (Priority: P2)
+
+**Goal**: Users should be able to write SQL queries starting with a `FROM` clause and completely omitting the `SELECT` clause, implicitly resulting in a `SELECT *` projection.
+
+**Independent Test**: New tests in `src/parser/parser.rs` verifying `FROM table_name;` parses correctly and implicitly adds `SELECT *`.
+
+### Tests for User Story 2 ⚠️
+
+- [x] T020 [P] [US2] Add parser tests in `src/parser/parser.rs` to verify `FROM tbl` without a `SELECT` parses equivalently to `SELECT * FROM tbl`.
+- [x] T021 [P] [US2] Add parser tests in `src/parser/parser.rs` to verify `FROM tbl WHERE x > 1` parses equivalently to `SELECT * FROM tbl WHERE x > 1`.
+
+### Implementation for User Story 2
+
+- [x] T022 [US2] Modify `parse_from_first_statement` in `src/parser/statements.rs` so that if the clause parsing loop finishes without having parsed a `SELECT` clause (i.e. `columns` is empty), it defaults the `columns` field to `vec![Expression::Star(...)]`.
+- [x] T023 [US2] Verify execution integration test. Add an integration test in `tests/` to actually execute a query like `FROM memory_table` to ensure end-to-end execution works seamlessly because of the AST rewrite.
+- [x] T024 [US2] Run `make test` to verify the implicit `SELECT *` tests pass.
+
+**Checkpoint**: At this point, User Story 2 should be fully functional, and queries omitting `SELECT` should work perfectly.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories and code quality verification.
+
+- [x] T030 [P] Ensure no `unwrap()` or `expect()` were added in `src/parser/statements.rs`.
+- [x] T031 Verify `make lint` passes with no warnings.
+- [x] T032 Verify `make license` passes to ensure headers are intact.
+- [x] T033 Run `make test-all` to ensure no existing tests or other SQL dialects were broken by the new parser loop.
+- [x] T034 Run `make coverage-check` to verify test coverage hasn't dropped.

--- a/src/bin/workspace/mod.rs
+++ b/src/bin/workspace/mod.rs
@@ -1,3 +1,18 @@
+// Copyright 2025 Stoolap Contributors
+// Copyright 2025 Oxibase Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use oxibase::api::Database;
 use oxibase::Value;
 

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -38,6 +38,7 @@ impl Parser {
             let keyword = self.cur_token.literal.to_uppercase();
             match keyword.as_str() {
                 "SELECT" => self.parse_select_statement().map(Statement::Select),
+                "FROM" => self.parse_from_first_statement().map(Statement::Select),
                 "WITH" => self.parse_with_statement(),
                 "INSERT" => self.parse_insert_statement().map(Statement::Insert),
                 "UPDATE" => self.parse_update_statement().map(Statement::Update),
@@ -210,6 +211,148 @@ impl Parser {
             if self.peek_token_is_keyword("ONLY") {
                 self.next_token();
             }
+        }
+
+        self.current_clause.clear();
+        Some(stmt)
+    }
+
+    /// Parse a FROM-first statement (DuckDB-style)
+    pub fn parse_from_first_statement(&mut self) -> Option<SelectStatement> {
+        let token = self.cur_token.clone(); // The FROM token
+
+        let mut stmt = SelectStatement {
+            token,
+            distinct: false,
+            columns: Vec::new(),
+            with: None,
+            table_expr: None,
+            where_clause: None,
+            group_by: GroupByClause::default(),
+            having: None,
+            window_defs: Vec::new(),
+            order_by: Vec::new(),
+            limit: None,
+            offset: None,
+            set_operations: Vec::new(),
+        };
+
+        // Parse FROM clause
+        self.next_token(); // move to table expression
+        stmt.table_expr = Some(Box::new(self.parse_table_expression()?));
+
+        // Enter loop to parse subsequent clauses in any order
+        loop {
+            if !self.peek_token_is(TokenType::Keyword) {
+                break;
+            }
+
+            let keyword = self.peek_token.literal.to_uppercase();
+            match keyword.as_str() {
+                "SELECT" => {
+                    self.next_token(); // consume SELECT
+
+                    // Check for DISTINCT
+                    if self.peek_token_is_keyword("DISTINCT") {
+                        self.next_token();
+                        stmt.distinct = true;
+                    }
+
+                    self.next_token();
+                    stmt.columns = self.parse_select_columns();
+                }
+                "WHERE" => {
+                    self.next_token(); // consume WHERE
+                    self.current_clause = "WHERE".to_string();
+                    self.next_token();
+                    stmt.where_clause = Some(Box::new(self.parse_expression(Precedence::Lowest)?));
+                }
+                "GROUP" => {
+                    self.next_token(); // consume GROUP
+                    if !self.expect_keyword("BY") {
+                        return None;
+                    }
+                    self.current_clause = "GROUP BY".to_string();
+                    stmt.group_by = self.parse_group_by_clause();
+                }
+                "HAVING" => {
+                    self.next_token(); // consume HAVING
+                    self.current_clause = "HAVING".to_string();
+                    self.next_token();
+                    stmt.having = Some(Box::new(self.parse_expression(Precedence::Lowest)?));
+                }
+                "WINDOW" => {
+                    self.next_token(); // consume WINDOW
+                    self.current_clause = "WINDOW".to_string();
+                    stmt.window_defs = self.parse_window_definitions();
+                }
+                "ORDER" => {
+                    self.next_token(); // consume ORDER
+                    if !self.expect_keyword("BY") {
+                        return None;
+                    }
+                    self.current_clause = "ORDER BY".to_string();
+                    stmt.order_by = self.parse_order_by_expressions();
+                }
+                "LIMIT" => {
+                    self.next_token(); // consume LIMIT
+                    self.current_clause = "LIMIT".to_string();
+                    self.next_token();
+                    stmt.limit = Some(Box::new(self.parse_expression(Precedence::Lowest)?));
+                }
+                "OFFSET" => {
+                    self.next_token(); // consume OFFSET
+                    self.current_clause = "OFFSET".to_string();
+                    self.next_token();
+                    stmt.offset = Some(Box::new(self.parse_expression(Precedence::Lowest)?));
+
+                    if self.peek_token_is_keyword("ROWS") || self.peek_token_is_keyword("ROW") {
+                        self.next_token();
+                    }
+                }
+                "FETCH" => {
+                    self.next_token(); // consume FETCH
+
+                    if !self.peek_token_is_keyword("FIRST") && !self.peek_token_is_keyword("NEXT") {
+                        self.add_error(format!(
+                            "expected FIRST or NEXT after FETCH at {}",
+                            self.peek_token.position
+                        ));
+                        return None;
+                    }
+                    self.next_token(); // consume FIRST/NEXT
+
+                    self.current_clause = "FETCH".to_string();
+                    self.next_token();
+                    stmt.limit = Some(Box::new(self.parse_expression(Precedence::Lowest)?));
+
+                    if self.peek_token_is_keyword("ROWS") || self.peek_token_is_keyword("ROW") {
+                        self.next_token();
+                    }
+
+                    if self.peek_token_is_keyword("ONLY") {
+                        self.next_token();
+                    }
+                }
+                "UNION" | "INTERSECT" | "EXCEPT" => {
+                    if let Some(set_op) = self.parse_set_operation() {
+                        stmt.set_operations.push(set_op);
+                    } else {
+                        break;
+                    }
+                }
+                _ => {
+                    // Unknown or unexpected keyword, break the loop
+                    break;
+                }
+            }
+        }
+
+        // If no SELECT clause was provided, default to SELECT *
+        if stmt.columns.is_empty() {
+            stmt.columns.push(Expression::Star(StarExpression {
+                token: Token::new(TokenType::Operator, "*", stmt.token.position),
+            }));
         }
 
         self.current_clause.clear();
@@ -4384,5 +4527,43 @@ mod tests {
         } else {
             panic!("Expected CopyStatement");
         }
+    }
+
+    #[test]
+    fn test_parse_from_first_with_select() {
+        let stmt1 = parse_stmt("FROM tbl SELECT a, b").unwrap();
+        let stmt2 = parse_stmt("SELECT a, b FROM tbl").unwrap();
+        assert_eq!(stmt1.to_string(), stmt2.to_string());
+    }
+
+    #[test]
+    fn test_parse_from_first_complex_source() {
+        let stmt1 = parse_stmt("FROM (VALUES (1)) t(a) SELECT a").unwrap();
+        let stmt2 = parse_stmt("SELECT a FROM (VALUES (1)) t(a)").unwrap();
+        assert_eq!(stmt1.to_string(), stmt2.to_string());
+    }
+
+    #[test]
+    fn test_parse_from_first_any_order() {
+        let stmt1 = parse_stmt("FROM tbl WHERE a > 1 SELECT a, b ORDER BY a LIMIT 10").unwrap();
+        let stmt2 = parse_stmt("SELECT a, b FROM tbl WHERE a > 1 ORDER BY a LIMIT 10").unwrap();
+        assert_eq!(stmt1.to_string(), stmt2.to_string());
+
+        let stmt3 = parse_stmt("FROM tbl ORDER BY a SELECT a, b LIMIT 10 WHERE a > 1").unwrap();
+        assert_eq!(stmt3.to_string(), stmt2.to_string());
+    }
+
+    #[test]
+    fn test_parse_from_first_without_select() {
+        let stmt1 = parse_stmt("FROM tbl").unwrap();
+        let stmt2 = parse_stmt("SELECT * FROM tbl").unwrap();
+        assert_eq!(stmt1.to_string(), stmt2.to_string());
+    }
+
+    #[test]
+    fn test_parse_from_first_without_select_where() {
+        let stmt1 = parse_stmt("FROM tbl WHERE x > 1").unwrap();
+        let stmt2 = parse_stmt("SELECT * FROM tbl WHERE x > 1").unwrap();
+        assert_eq!(stmt1.to_string(), stmt2.to_string());
     }
 }

--- a/tests/from_first_syntax_test.rs
+++ b/tests/from_first_syntax_test.rs
@@ -1,0 +1,77 @@
+// Copyright 2025 Stoolap Contributors
+// Copyright 2025 Oxibase Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use oxibase::Database;
+
+#[tokio::test]
+async fn test_from_first_syntax() {
+    let db = Database::open("memory://test_from_first").unwrap();
+
+    // Setup table
+    db.execute(
+        "CREATE TABLE users (id INTEGER, name TEXT, age INTEGER)",
+        (),
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO users VALUES (1, 'Alice', 30), (2, 'Bob', 25), (3, 'Charlie', 35)",
+        (),
+    )
+    .unwrap();
+
+    // Test 1: FROM ... SELECT ...
+    let rows = db
+        .query("FROM users SELECT id, name", ())
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert_eq!(rows.len(), 3);
+    let mut names: Vec<String> = rows
+        .into_iter()
+        .map(|r| r.get::<String>(1).unwrap())
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["Alice", "Bob", "Charlie"]);
+
+    // Test 2: FROM ... WHERE ... SELECT ...
+    let rows = db
+        .query("FROM users WHERE age > 25 SELECT name", ())
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert_eq!(rows.len(), 2);
+    let mut names: Vec<String> = rows
+        .into_iter()
+        .map(|r| r.get::<String>(0).unwrap())
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["Alice", "Charlie"]);
+
+    // Test 3: FROM ... (implicit SELECT *)
+    let rows_iter = db.query("FROM users", ()).unwrap();
+    assert_eq!(rows_iter.column_count(), 3);
+    let rows = rows_iter.collect_vec().unwrap();
+    assert_eq!(rows.len(), 3);
+
+    // Test 4: FROM ... ORDER BY ... LIMIT ...
+    let rows = db
+        .query("FROM users ORDER BY age DESC LIMIT 1", ())
+        .unwrap()
+        .collect_vec()
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    let name: String = rows[0].get(1).unwrap();
+    assert_eq!(name, "Charlie");
+}


### PR DESCRIPTION
## Summary
- Adds support for DuckDB-style `FROM`-first queries.
- Modifies the SQL Parser to accept `FROM` leading statements and allow subsequent clauses (`SELECT`, `WHERE`, `ORDER BY`, etc.) to appear in any order.
- Implicitly projects `SELECT *` if the `SELECT` clause is omitted.
- Includes comprehensive unit tests in `src/parser/statements.rs` and integration tests in `tests/from_first_syntax_test.rs`.