### PR TITLE
feat: Standardize Internal API Alignment across scripting backends

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This file contains high-signal, repo-specific context to help agents work effect
   - Standard tests: `make test` (or `cargo nextest run --profile ci`)
   - All features: `make test-all`
 - **Linting & Formatting**: Use `make lint` (runs `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings`).
+  - **IMPORTANT**: ALWAYS run `make lint` and fix any issues before pushing code to avoid CI failures.
 - **Features**: The codebase has optional scripting backends: `js` (Boa), `python` (RustPython), and `rhai` (default). When testing or building specific backend logic, ensure you pass the right feature flag (e.g., `--features js`).
 - **License Headers**: All `.rs` files require an Apache-2.0 license header. You can use `./scripts/fix_copyrights.sh` to fix headers or run `make license` to verify them. 
 - **Code Coverage**: Verify your changes do not drop the overall test coverage below the minimum threshold by running `make coverage-check`. You can also generate an HTML report using `make coverage-html`.
@@ -33,6 +34,6 @@ The system is an autonomous relational database management system.
 - Binary artifacts are built for Linux, macOS, and Windows on release. Ensure any new dependencies support cross-compilation on these targets.
 
 <!-- SPECKIT START -->
-specs/040-html-js-dap-debugger/plan.md
+specs/042-workflow-ide/plan.md
 <!-- SPECKIT END -->
 

--- a/docs/_docs/how-to/json-api.md
+++ b/docs/_docs/how-to/json-api.md
@@ -129,7 +129,7 @@ The response is a JSON object containing the values of the `OUT` or `INOUT` para
 
 #### Accessing HTTP Metadata from Procedures
 
-When a procedure is invoked via `/api/rpc/`, it can read the incoming HTTP request headers using the built-in `get_http_header('header_name')` SQL function. This is useful for passing authentication tokens, user agents, or custom metadata securely into your business logic.
+When a procedure is invoked via `/api/rpc/`, it can read the incoming HTTP request headers using the built-in `oxibase::get_http_header('header_name')` SQL function. This is useful for passing authentication tokens, user agents, or custom metadata securely into your business logic.
 
 ```sql
 CREATE PROCEDURE get_my_ip(OUT ip_address TEXT)

--- a/docs/_docs/references/procedures.md
+++ b/docs/_docs/references/procedures.md
@@ -86,8 +86,8 @@ You can explicitly control transaction boundaries inside stored procedures. This
 ### Language Syntax
 
 - **PL/SQL**: Use native `COMMIT;`, `ROLLBACK;`, and `BEGIN;` statements.
-- **Rhai**: Use the globally registered `commit()`, `rollback()`, and `begin()` functions.
-- **JavaScript (Boa)**: Use the globally registered `commit()`, `rollback()`, and `begin()` functions.
+- **Rhai**: Use `oxibase::commit()`, `oxibase::rollback()`, and `oxibase::begin()`.
+- **JavaScript (Boa)**: Use `oxibase.commit()`, `oxibase.rollback()`, and `oxibase.begin()`.
 - **Python**: Use `oxibase.commit()`, `oxibase.rollback()`, and `oxibase.begin()`.
 
 ### Example (PL/SQL)

--- a/specs/009-service-invocation/quickstart.md
+++ b/specs/009-service-invocation/quickstart.md
@@ -9,7 +9,7 @@ First, define a procedure in the database using SQL or any supported scripting l
 ```sql
 CREATE PROCEDURE process_order(user_id INTEGER, amount INTEGER)
 LANGUAGE RHAI AS $$
-    let auth = get_http_header("Authorization");
+    let auth = oxibase::get_http_header("Authorization");
     if auth == () || auth == null {
         throw "Unauthorized";
     }

--- a/src/functions/backends/python.rs
+++ b/src/functions/backends/python.rs
@@ -64,7 +64,10 @@ mod oxibase_py_module {
     }
 
     #[pyfunction]
-    fn get_http_header(header_name: PyStrRef, vm: &VirtualMachine) -> PyResult<rustpython_vm::PyObjectRef> {
+    fn get_http_header(
+        header_name: PyStrRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<rustpython_vm::PyObjectRef> {
         let mut header_value = None;
         crate::functions::context::HTTP_HEADERS.with(|headers| {
             if let Some(map) = headers.borrow().as_ref() {

--- a/src/functions/backends/python.rs
+++ b/src/functions/backends/python.rs
@@ -64,6 +64,27 @@ mod oxibase_py_module {
     }
 
     #[pyfunction]
+    fn get_http_header(header_name: PyStrRef, vm: &VirtualMachine) -> PyResult<rustpython_vm::PyObjectRef> {
+        let mut header_value = None;
+        crate::functions::context::HTTP_HEADERS.with(|headers| {
+            if let Some(map) = headers.borrow().as_ref() {
+                let search_key = header_name.to_string().to_lowercase();
+                for (k, v) in map {
+                    if k.to_lowercase() == search_key {
+                        header_value = Some(v.clone());
+                        break;
+                    }
+                }
+            }
+        });
+
+        match header_value {
+            Some(v) => Ok(vm.ctx.new_str(v).into()),
+            None => Ok(vm.ctx.none()),
+        }
+    }
+
+    #[pyfunction]
     fn _append_stdout(s: PyStrRef) {
         crate::functions::context::append_stdout(s.as_ref());
     }

--- a/src/functions/backends/rhai.rs
+++ b/src/functions/backends/rhai.rs
@@ -42,7 +42,17 @@ impl RhaiBackend {
         engine.register_type_with_name::<OldRowProxy>("OldRowProxy");
         engine.register_indexer_get(|proxy: &mut OldRowProxy, prop: &str| proxy.get(prop));
 
-        engine.register_fn(
+        let mut oxibase_module = rhai::Module::new();
+        oxibase_module.set_native_fn(
+            "execute",
+            |sql: rhai::ImmutableString| -> std::result::Result<i64, Box<rhai::EvalAltResult>> {
+                match crate::functions::backends::execute_sql_query(&sql) {
+                    Ok(res) => Ok(res.rows_affected()),
+                    Err(e) => Err(e.to_string().into()),
+                }
+            },
+        );
+        oxibase_module.set_native_fn(
             "get_http_header",
             |header_name: String| -> std::result::Result<rhai::Dynamic, Box<rhai::EvalAltResult>> {
                 let mut header_value = None;
@@ -64,8 +74,7 @@ impl RhaiBackend {
                 }
             },
         );
-
-        engine.register_fn(
+        oxibase_module.set_native_fn(
             "commit",
             || -> std::result::Result<(), Box<rhai::EvalAltResult>> {
                 match crate::functions::backends::commit_transaction() {
@@ -74,8 +83,7 @@ impl RhaiBackend {
                 }
             },
         );
-
-        engine.register_fn(
+        oxibase_module.set_native_fn(
             "rollback",
             || -> std::result::Result<(), Box<rhai::EvalAltResult>> {
                 match crate::functions::backends::rollback_transaction() {
@@ -84,24 +92,11 @@ impl RhaiBackend {
                 }
             },
         );
-
-        engine.register_fn(
+        oxibase_module.set_native_fn(
             "begin",
             || -> std::result::Result<(), Box<rhai::EvalAltResult>> {
                 match crate::functions::backends::begin_transaction() {
                     Ok(_) => Ok(()),
-                    Err(e) => Err(e.to_string().into()),
-                }
-            },
-        );
-
-        // Register oxibase module
-        let mut oxibase_module = rhai::Module::new();
-        oxibase_module.set_native_fn(
-            "execute",
-            |sql: rhai::ImmutableString| -> std::result::Result<i64, Box<rhai::EvalAltResult>> {
-                match crate::functions::backends::execute_sql_query(&sql) {
-                    Ok(res) => Ok(res.rows_affected()),
                     Err(e) => Err(e.to_string().into()),
                 }
             },

--- a/tests/procedure_multilang_tests.rs
+++ b/tests/procedure_multilang_tests.rs
@@ -153,15 +153,15 @@ fn test_js_transaction_commit_rollback() {
         AS '
             // Insert and commit
             oxibase.execute("INSERT INTO tx_test_js(id, val) VALUES (1, ''first'')");
-            commit();
+            oxibase.commit();
             
             // Insert and rollback
             oxibase.execute("INSERT INTO tx_test_js(id, val) VALUES (2, ''second'')");
-            rollback();
+            oxibase.rollback();
             
             // Insert after rollback and commit
             oxibase.execute("INSERT INTO tx_test_js(id, val) VALUES (3, ''third'')");
-            commit();
+            oxibase.commit();
         ';
     "#;
 

--- a/tests/procedure_tests.rs
+++ b/tests/procedure_tests.rs
@@ -139,15 +139,15 @@ fn test_rhai_transaction_commit_rollback() {
         AS '
             // Insert and commit
             oxibase::execute("INSERT INTO tx_test(id, val) VALUES (1, ''first'')");
-            commit();
+            oxibase::commit();
             
             // Insert and rollback
             oxibase::execute("INSERT INTO tx_test(id, val) VALUES (2, ''second'')");
-            rollback();
+            oxibase::rollback();
             
             // Insert after rollback and commit
             oxibase::execute("INSERT INTO tx_test(id, val) VALUES (3, ''third'')");
-            commit();
+            oxibase::commit();
         ';
     "#;
 

--- a/tests/server_rpc_tests.rs
+++ b/tests/server_rpc_tests.rs
@@ -125,7 +125,7 @@ async fn test_rpc_procedure_headers() {
         r#"
         CREATE PROCEDURE check_auth(OUT res TEXT)
         LANGUAGE rhai AS '
-            let token = get_http_header("Authorization");
+            let token = oxibase::get_http_header("Authorization");
             if token == () {
                 res = "missing";
             } else {


### PR DESCRIPTION
Fixes #98.

- Standardized the interface so that all scripting languages use a cohesive `oxibase` object/module.
- Moved all Oxibase-specific global functions in Rhai (`commit()`, `rollback()`, `begin()`, `get_http_header()`) into the `oxibase` module.
- Added `get_http_header()` to Python's `oxibase` module to ensure it matches the Rhai module's signature and features.
- Updated all inline documentation and examples to reflect the new unified `oxibase.*` API namespace.
- Updated all tutorial and testing scripts to use the new aligned API.