### PR TITLE
Potential fix for code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/docs/assets/js/panes.js
+++ b/docs/assets/js/panes.js
@@ -458,14 +458,17 @@ document.addEventListener("DOMContentLoaded", function () {
         // Create new pane with spine and body
         const newPane = document.createElement("div");
         newPane.className = "pane";
-        newPane.innerHTML = `
-        <div class="pane-content">
-          <div class="pane-header">${titleText}</div>
-          <div class="pane-body">
-            ${mainContent.outerHTML}
-          </div>
-        </div>
-      `;
+        const paneContent = document.createElement("div");
+        paneContent.className = "pane-content";
+        const paneHeader = document.createElement("div");
+        paneHeader.className = "pane-header";
+        paneHeader.textContent = titleText;
+        const paneBody = document.createElement("div");
+        paneBody.className = "pane-body";
+        paneBody.appendChild(mainContent.cloneNode(true));
+        paneContent.appendChild(paneHeader);
+        paneContent.appendChild(paneBody);
+        newPane.appendChild(paneContent);
 
         this.paneSystem.panesContainer.appendChild(newPane);
         newPane.dataset.url = href;


### PR DESCRIPTION
Potential fix for [https://github.com/oxibase/oxibase/security/code-scanning/12](https://github.com/oxibase/oxibase/security/code-scanning/12)

The safest fix is to stop interpolating `titleText` into an `innerHTML` string. Build the pane DOM using element creation APIs and assign title via `textContent`, which preserves text semantics and prevents HTML interpretation.

Best single fix (without changing functionality) in `docs/assets/js/panes.js` around lines 459–468:
- Replace `newPane.innerHTML = \`...\`` construction with explicit DOM node creation:
  - create `.pane-content`, `.pane-header`, `.pane-body` elements.
  - set `paneHeader.textContent = titleText`.
  - append `mainContent.cloneNode(true)` into `.pane-body` (equivalent to embedding `mainContent.outerHTML`).
  - assemble and append into `newPane`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
